### PR TITLE
Update install scripts

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -135,7 +135,6 @@ mil_system_install --no-install-recommends \
 # Generally, our packages shouldn't break the system, but we will continue to monitor
 # this for the future. ROS2 and rosdep have a hard time with virtual environments,
 # and using system pip packages in the past has been fine.
-# Attempt to install vcstool using apt-get or pip if apt-get does not work
 sudo pip3 install -U vcstool --break-system-packages
 
 cat <<EOF

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -221,7 +221,7 @@ EOF
 sudo pip3 install -U colcon-common-extensions --break-system-packages
 
 # Initialize rosdep
-sudo apt-get install python3-rosdep
+sudo apt-get install -y python3-rosdep
 
 # Update rosdep
 sudo rm -rf /etc/ros/rosdep/sources.list.d/* # Delete this file first - if not deleted, error could be thrown

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -131,14 +131,12 @@ mil_system_install --no-install-recommends \
 	wget \
 	vim
 
-# Turn on breaking system packages in pip (set to 0 by default in noble)
+# Turn on breaking system packages 
 # Generally, our packages shouldn't break the system, but we will continue to monitor
 # this for the future. ROS2 and rosdep have a hard time with virtual environments,
 # and using system pip packages in the past has been fine.
-python3 -m pip config set global.break-system-packages true
-
 # Attempt to install vcstool using apt-get or pip if apt-get does not work
-sudo apt install -y python3-vcstool || sudo pip3 install -U vcstool
+sudo pip3 install -U vcstool --break-system-packages
 
 cat <<EOF
 $(color "$Pur")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -217,6 +217,9 @@ $(color "$Pur")Initializing rosdep...
 $(hash_header)$(color "$Res")
 EOF
 
+# Install Colcon
+sudo pip3 install -U colcon-common-extensions --break-system-packages
+
 # Initialize rosdep
 sudo apt-get install python3-rosdep
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -131,11 +131,13 @@ mil_system_install --no-install-recommends \
 	wget \
 	vim
 
-# Turn on breaking system packages 
+# Turn on breaking system packages in pip (set to 0 by default in noble)
 # Generally, our packages shouldn't break the system, but we will continue to monitor
 # this for the future. ROS2 and rosdep have a hard time with virtual environments,
 # and using system pip packages in the past has been fine.
-sudo pip3 install -U vcstool --break-system-packages
+sudo python3 -m pip config set global.break-system-packages true
+
+sudo pip3 install -U vcstool
 
 cat <<EOF
 $(color "$Pur")
@@ -206,7 +208,7 @@ if which update-manager >/dev/null 2>&1; then
 fi
 
 # Install Python 3 dependencies
-sudo pip3 install -r requirements.txt --break-system-packages
+sudo pip3 install -r requirements.txt
 
 cat <<EOF
 $(color "$Pur")
@@ -217,7 +219,7 @@ $(hash_header)$(color "$Res")
 EOF
 
 # Install Colcon
-sudo pip3 install -U colcon-common-extensions --break-system-packages
+sudo pip3 install -U colcon-common-extensions
 
 # Initialize rosdep
 sudo apt-get install -y python3-rosdep


### PR DESCRIPTION
* The line 
```bash
python3 -m pip config set global.break-system-packages true
sudo apt install -y python3-vcstool || sudo pip3 install -U vcstool
``` 
did not seem work on my system so I switched it to 
```bash
sudo pip3 install -U vcstool --break-system-packages
```
* I also noticed that colcon was not automatically installed so I also added it 
```bash
# Install Colcon
sudo pip3 install -U colcon-common-extensions --break-system-packages
```
* Lastly I just added a ``-y`` to this line so that it doesnt prompt the user 
```bash
sudo apt-get install -y python3-rosdep
```