### PR TITLE
added bashrc to tmux shells

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -294,6 +294,15 @@ mil_user_setup_rc() {
 			} >>~/.bashrc
 		fi
 	fi
+
+	# Copies bashrc to interactive login shells (like tmux)
+	echo 'if [ -n "$BASH_VERSION" ] && [ -n "$PS1" ]; then
+		# include .bashrc if it exists
+		if [ -f "$HOME/.bashrc" ]; then
+			. "$HOME/.bashrc"
+		fi
+	fi' >> ~/.profile
+
 }
 
 add_hosts_entry() {


### PR DESCRIPTION
Thanks to https://unix.stackexchange.com/questions/320465/new-tmux-sessions-do-not-source-bashrc-file
Made it so when you use tmux it still loads the .bashrc