### PR TITLE
Added reset function to UnderwaterCamera to lock SimulateUnderwater()

### DIFF
--- a/src/subjugator/simulation/subjugator_description/urdf/sub9.urdf.xacro
+++ b/src/subjugator/simulation/subjugator_description/urdf/sub9.urdf.xacro
@@ -72,12 +72,14 @@
     parent="base_link" 
     xyz="-0.32 -0.014274 -0.050" 
     rpy="0 0 3.14159"
+    use_image_processing="true"
   />
   <xacro:mil_camera 
     name="down_cam" 
     parent="base_link" 
     xyz="-0.15222 0.027913 -0.22" 
     rpy="0 1.57 0"
+    use_image_processing="true"
   />
 
 

--- a/src/subjugator/simulation/subjugator_description/urdf/xacro/camera.xacro
+++ b/src/subjugator/simulation/subjugator_description/urdf/xacro/camera.xacro
@@ -4,7 +4,7 @@
   <xacro:macro
     name="mil_camera"
     params="name parent xyz rpy
-            use_image_processing=false
+            use_image_processing=true
             width=960 height=600 fov=1.047 fps=30"
   >
     <!-- Camera Link -->

--- a/src/subjugator/simulation/subjugator_gazebo/include/UnderwaterCamera.hh
+++ b/src/subjugator/simulation/subjugator_gazebo/include/UnderwaterCamera.hh
@@ -33,7 +33,8 @@ namespace dave_gz_sensor_plugins
 {
 class UnderwaterCamera : public gz::sim::System,
                          public gz::sim::ISystemConfigure,
-                         public gz::sim::ISystemPostUpdate
+                         public gz::sim::ISystemPostUpdate,
+                         public gz::sim::ISystemReset
 {
 public:
   UnderwaterCamera();
@@ -45,6 +46,10 @@ public:
 
   void PostUpdate(
     const gz::sim::UpdateInfo & info, const gz::sim::EntityComponentManager & ecm) override;
+  
+  void Reset(
+    const gz::sim::UpdateInfo &_info,
+    gz::sim::EntityComponentManager &_ecm) override;
 
   void CameraCallback(const gz::msgs::Image & image);
 

--- a/src/subjugator/simulation/subjugator_gazebo/src/UnderwaterCamera.cc
+++ b/src/subjugator/simulation/subjugator_gazebo/src/UnderwaterCamera.cc
@@ -357,7 +357,6 @@ void UnderwaterCamera::CameraCallback(const gz::msgs::Image & msg)
     {
       this->dataPtr->lastImage = msg;
       this->dataPtr->firstImage = false;
-      this->dataPtr->isReset = false;
     }
     else
     {
@@ -371,6 +370,7 @@ void UnderwaterCamera::CameraCallback(const gz::msgs::Image & msg)
       cv::Mat output_image = this->ConvertGazeboToOpenCV(this->dataPtr->lastImage);
 
       // Simulate underwater
+      this->dataPtr->isReset = false;
       cv::Mat simulated_image = this->SimulateUnderwater(image, depth_image, output_image);
 
       // Publish simulated image


### PR DESCRIPTION
fixes #55 

Reset bringing back the robot was fixed in a previous PR, however it would crash if not paused before resetting. This fix overrides the reset function in UnderwaterCamera and sets a locking variable in the dataPtr so that if gazebo reset while doing calculations for the SimulateUnderwater function, it will stop the function and return before a seg fault occurs.

