### PR TITLE
Carter thruster topic fix

### DIFF
--- a/src/subjugator/simulation/subjugator_description/urdf/sub9.urdf.xacro
+++ b/src/subjugator/simulation/subjugator_description/urdf/sub9.urdf.xacro
@@ -95,6 +95,8 @@
       <nRabsR>-750</nRabsR>
       <nR>-750</nR>
     </plugin>
+
+    <plugin filename="ThrusterBridge" name="thrusterBridge::ThrusterBridge"/>
   </gazebo>
 
   <!-- Cameras -->

--- a/src/subjugator/simulation/subjugator_gazebo/CMakeLists.txt
+++ b/src/subjugator/simulation/subjugator_gazebo/CMakeLists.txt
@@ -9,11 +9,11 @@ find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(mil_msgs REQUIRED)
+find_package(subjugator_msgs REQUIRED)
 
 find_package(OpenCV REQUIRED)
 
 find_package(subjugator_description REQUIRED)
-find_package(mil_msgs REQUIRED)
 
 find_package(gz-cmake3 REQUIRED)
 find_package(gz-plugin2 REQUIRED COMPONENTS register)
@@ -52,6 +52,9 @@ add_library(DepthSensor SHARED src/DepthSensor.cc)
 # Plugin 3: Hydrophone
 add_library(Hydrophone SHARED src/Hydrophone.cc)
 
+# Plugin 4: Thruster Bridge
+add_library(ThrusterBridge SHARED src/ThrusterBridge.cc)
+
 # Ensures plugin can see include directory to access its header files
 target_include_directories(ExamplePlugin PRIVATE include)
 
@@ -62,6 +65,8 @@ target_include_directories(DVLBridge PRIVATE include)
 target_include_directories(DepthSensor PRIVATE include)
 
 target_include_directories(Hydrophone PRIVATE include)
+
+target_include_directories(ThrusterBridge PRIVATE include)
 
 # Add additional needed libraries
 target_link_libraries(
@@ -83,6 +88,9 @@ target_link_libraries(Hydrophone gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
 # Link libraries for DepthSensor plugin
 target_link_libraries(DepthSensor gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
 
+# Link libraries for ThrusterBridge plugin
+target_link_libraries(ThrusterBridge gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
+
 # Specify dependencies using ament_target_dependencies
 ament_target_dependencies(
   ExamplePlugin
@@ -98,6 +106,8 @@ ament_target_dependencies(DVLBridge nav_msgs rclcpp geometry_msgs std_msgs)
 ament_target_dependencies(DepthSensor rclcpp mil_msgs sensor_msgs)
 
 ament_target_dependencies(Hydrophone rclcpp geometry_msgs mil_msgs)
+
+ament_target_dependencies(ThrusterBridge rclcpp subjugator_msgs geometry_msgs)
 
 # Install the plugins
 install(TARGETS UnderwaterCamera ExamplePlugin DVLBridge Hydrophone DepthSensor

--- a/src/subjugator/simulation/subjugator_gazebo/CMakeLists.txt
+++ b/src/subjugator/simulation/subjugator_gazebo/CMakeLists.txt
@@ -111,7 +111,7 @@ ament_target_dependencies(ThrusterBridge rclcpp subjugator_msgs geometry_msgs)
 
 # Install the plugins
 install(TARGETS UnderwaterCamera ExamplePlugin DVLBridge Hydrophone DepthSensor
-        LIBRARY DESTINATION lib/${PROJECT_NAME})
+                ThrusterBridge LIBRARY DESTINATION lib/${PROJECT_NAME})
 
 # Install headers
 install(DIRECTORY include/ DESTINATION include)

--- a/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
+++ b/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
@@ -1,0 +1,70 @@
+#ifndef HYDROPHONE__HH_
+#define HYDROPHONE__HH_
+
+#include <iostream>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <gz/math/Pose3.hh>  // For gz::math::Pose3d
+#include <gz/sim/EntityComponentManager.hh>
+#include <gz/sim/InstallationDirectories.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/System.hh>  // For gz::sim::System
+#include <gz/sim/World.hh>
+#include <gz/sim/components/Name.hh>  // For gz::sim::components::Name
+#include <gz/sim/components/Pose.hh>  // For gz::sim::components::Pose
+#include <sdf/Element.hh>
+#include <sdf/World.hh>
+#include <sdf/sdf.hh>
+
+namespace hydrophone
+{
+class Hydrophone : public gz::sim::System, public gz::sim::ISystemConfigure, public gz::sim::ISystemPostUpdate
+{
+  public:
+    Hydrophone();
+    ~Hydrophone();
+
+    // Configure() - Gathers Info at the start of the simulation //
+    void Configure(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
+                   gz::sim::EntityComponentManager &ecm, gz::sim::EventManager &eventMgr) override;
+
+    // FormatPinger() - Extract frequency and name //
+    void FormatPinger(std::string &entityName);
+
+    // System PostUpdate - Called every simulation step to update pinger/hydrophone distances //
+    void PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComponentManager const &ecm) override;
+
+    // GatherWorldInfo() - Scrape info from the worldSDF to get pinger info //
+    void GatherWorldInfo(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
+                         gz::sim::EntityComponentManager const &ecm);
+
+  private:
+    // Boolean so GatherWorldInfo is only called once //
+    bool worldGathered = false;
+
+    // Stored Entities //
+    gz::sim::Entity modelEntity_{ gz::sim::kNullEntity };       // World Entity
+    gz::sim::Entity hydrophoneEntity_{ gz::sim::kNullEntity };  // Hydrophone Entity
+
+    // World SDF //
+    std::shared_ptr<sdf::Element const> sdf_;
+
+    // ROS node + publisher //
+    std::shared_ptr<rclcpp::Node> rosNode_;
+    rclcpp::Publisher<mil_msgs::msg::ProcessedPing>::SharedPtr pingPub_;
+
+    // Vectors for Pinger Info //
+    std::vector<std::string> pingerNames_;
+    std::vector<gz::math::Pose3d> pingerLocations_;
+    std::vector<double> pingerFrequencies_;
+
+    // Sub9 Pose //
+    gz::math::Pose3d hydrophonePose_{ gz::math::Pose3d::Zero };
+
+    // Difference Vectors - Where the pinger is relative to the hydrophone
+    std::vector<gz::math::Vector3d> pingerDiffs_;
+};
+
+}  // namespace hydrophone
+#endif  // HYDROPHONE_HH

--- a/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
+++ b/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
@@ -1,24 +1,20 @@
-#ifndef THRUSTERBRIDGE__HH_
-#define THRUSTERBRIDGE__HH_
+#pragma once
 
 #include <iostream>
-#include <vector>
+#include <string>
+#include <unordered_map>
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <gz/math/Pose3.hh>  // For gz::math::Pose3d
+#include <gz/sim/Entity.hh>
 #include <gz/sim/EntityComponentManager.hh>
 #include <gz/sim/EventManager.hh>
 #include <gz/sim/InstallationDirectories.hh>
-#include <gz/sim/Model.hh>
-#include <gz/sim/System.hh>  // For gz::sim::System
-#include <gz/sim/World.hh>
+#include <gz/sim/System.hh>           // For gz::sim::System
 #include <gz/sim/components/Name.hh>  // For gz::sim::components::Name
 #include <gz/sim/components/Pose.hh>  // For gz::sim::components::Pose
 #include <gz/transport/Node.hh>       // For gz::transport::Node
 #include <sdf/Element.hh>
-#include <sdf/World.hh>
-#include <sdf/sdf.hh>
 
 // The .msg file is named ProcessedPing.msg (PascalCase) but #include must be the name in snake_case
 #include "subjugator_msgs/msg/thruster_efforts.hpp"
@@ -34,16 +30,15 @@ class ThrusterBridge : public gz::sim::System, public gz::sim::ISystemConfigure,
     ThrusterBridge();
     ~ThrusterBridge();
 
-    // Configure() -  //
+    // Configure() -  Create ROS node that subscribes to /thruster_efforts & setup Gazebo Publishers //
     void Configure(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
                    gz::sim::EntityComponentManager &ecm, gz::sim::EventManager &eventMgr) override;
 
-    // System PostUpdate - //
+    // System PostUpdate - Run the ROS node //
     void PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComponentManager const &ecm) override;
 
   private:
     // ROS node + publisher //
-    rclcpp::Publisher<subjugator_msgs::msg::ThrusterEfforts>::SharedPtr thrustPublisher;
     rclcpp::Subscription<subjugator_msgs::msg::ThrusterEfforts>::SharedPtr thrustSubscription;
     std::shared_ptr<rclcpp::Node> thrustNode;
 
@@ -52,19 +47,10 @@ class ThrusterBridge : public gz::sim::System, public gz::sim::ISystemConfigure,
 
     // Callback for receiving thruster efforts //
     void receiveEffortCallback(subjugator_msgs::msg::ThrusterEfforts const &msg);
-    void receiveGazeboCallback(gz::msgs::Double const &msg);
 
     // Thruster efforts storage - FLV = Front Left Vertical, BRH = Back Right Horizontal //
-    std::vector<std::string> thrusterNames{ flh, frh, blh, brh, flv, frv, blv, brv };
-    float flh;
-    float frh;
-    float blh;
-    float brh;
-    float flv;
-    float frv;
-    float blv;
-    float brv;
+    std::unordered_map<std::string, float> thrusterEfforts;
+    std::unordered_map<std::string, gz::transport::Node::Publisher> publishers;
 };
 
 }  // namespace thrusterBridge
-#endif  // THRUSTERBRIDGE__HH_

--- a/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
+++ b/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
@@ -1,5 +1,5 @@
-#ifndef HYDROPHONE__HH_
-#define HYDROPHONE__HH_
+#ifndef THRUSTERBRIDGE__HH_
+#define THRUSTERBRIDGE__HH_
 
 #include <iostream>
 
@@ -7,64 +7,64 @@
 
 #include <gz/math/Pose3.hh>  // For gz::math::Pose3d
 #include <gz/sim/EntityComponentManager.hh>
+#include <gz/sim/EventManager.hh>
 #include <gz/sim/InstallationDirectories.hh>
 #include <gz/sim/Model.hh>
 #include <gz/sim/System.hh>  // For gz::sim::System
 #include <gz/sim/World.hh>
 #include <gz/sim/components/Name.hh>  // For gz::sim::components::Name
 #include <gz/sim/components/Pose.hh>  // For gz::sim::components::Pose
+#include <gz/transport/Node.hh>       // For gz::transport::Node
 #include <sdf/Element.hh>
 #include <sdf/World.hh>
 #include <sdf/sdf.hh>
 
-namespace hydrophone
+// The .msg file is named ProcessedPing.msg (PascalCase) but #include must be the name in snake_case
+#include "../../../subjugator_msgs/msg/thruster_efforts.hpp"
+#include "subjugator_msgs/msg/thruster_efforts.hpp"
+
+using std::placeholders::_1;
+
+namespace thrusterBridge
 {
-class Hydrophone : public gz::sim::System, public gz::sim::ISystemConfigure, public gz::sim::ISystemPostUpdate
+class ThrusterBridge : public gz::sim::System,
+                       public gz::sim::ISystemConfigure,
+                       public gz::sim::ISystemPostUpdate,
+                       public rclcpp::Node
 {
   public:
-    Hydrophone();
-    ~Hydrophone();
+    ThrusterBridge();
+    ~ThrusterBridge();
 
-    // Configure() - Gathers Info at the start of the simulation //
+    // Configure() -  //
     void Configure(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
                    gz::sim::EntityComponentManager &ecm, gz::sim::EventManager &eventMgr) override;
 
-    // FormatPinger() - Extract frequency and name //
-    void FormatPinger(std::string &entityName);
-
-    // System PostUpdate - Called every simulation step to update pinger/hydrophone distances //
+    // System PostUpdate - //
     void PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComponentManager const &ecm) override;
 
-    // GatherWorldInfo() - Scrape info from the worldSDF to get pinger info //
-    void GatherWorldInfo(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
-                         gz::sim::EntityComponentManager const &ecm);
-
   private:
-    // Boolean so GatherWorldInfo is only called once //
-    bool worldGathered = false;
-
-    // Stored Entities //
-    gz::sim::Entity modelEntity_{ gz::sim::kNullEntity };       // World Entity
-    gz::sim::Entity hydrophoneEntity_{ gz::sim::kNullEntity };  // Hydrophone Entity
-
-    // World SDF //
-    std::shared_ptr<sdf::Element const> sdf_;
-
     // ROS node + publisher //
     std::shared_ptr<rclcpp::Node> rosNode_;
-    rclcpp::Publisher<mil_msgs::msg::ProcessedPing>::SharedPtr pingPub_;
+    rclcpp::Publisher<subjugator_msgs::msg::ThrusterEfforts>::SharedPtr thrusterSub_;
 
-    // Vectors for Pinger Info //
-    std::vector<std::string> pingerNames_;
-    std::vector<gz::math::Pose3d> pingerLocations_;
-    std::vector<double> pingerFrequencies_;
+    // Gazebo Thruster Node //
+    gz::transport::Node gz_node;
 
-    // Sub9 Pose //
-    gz::math::Pose3d hydrophonePose_{ gz::math::Pose3d::Zero };
+    // Callback for receiving thruster efforts //
+    void receiveEffortCallback(subjugator_msgs::msg::ThrusterEfforts const &msg);
 
-    // Difference Vectors - Where the pinger is relative to the hydrophone
-    std::vector<gz::math::Vector3d> pingerDiffs_;
+    // Thruster efforts storage - FLV = Front Left Vertical, BRH = Back Right Horizontal //
+    std::vector<float> thrusterEfforts_;
+    float flh;
+    float frh;
+    float blh;
+    float brh;
+    float flv;
+    float frv;
+    float blv;
+    float brv;
 };
 
-}  // namespace hydrophone
-#endif  // HYDROPHONE_HH
+}  // namespace thrusterBridge
+#endif  // THRUSTERBRIDGE__HH_

--- a/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
+++ b/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
@@ -43,14 +43,16 @@ class ThrusterBridge : public gz::sim::System, public gz::sim::ISystemConfigure,
 
   private:
     // ROS node + publisher //
-    std::shared_ptr<rclcpp::Node> rosNode_;
-    rclcpp::Publisher<subjugator_msgs::msg::ThrusterEfforts>::SharedPtr thrusterSub_;
+    rclcpp::Publisher<subjugator_msgs::msg::ThrusterEfforts>::SharedPtr thrustPublisher;
+    rclcpp::Subscription<subjugator_msgs::msg::ThrusterEfforts>::SharedPtr thrustSubscription;
+    std::shared_ptr<rclcpp::Node> thrustNode;
 
     // Gazebo Thruster Node //
     gz::transport::Node gz_node;
 
     // Callback for receiving thruster efforts //
     void receiveEffortCallback(subjugator_msgs::msg::ThrusterEfforts const &msg);
+    void receiveGazeboCallback(subjugator_msgs::msg::ThrusterEfforts const &msg);
 
     // Thruster efforts storage - FLV = Front Left Vertical, BRH = Back Right Horizontal //
     std::vector<float> thrusterEfforts_;

--- a/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
+++ b/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
@@ -52,10 +52,10 @@ class ThrusterBridge : public gz::sim::System, public gz::sim::ISystemConfigure,
 
     // Callback for receiving thruster efforts //
     void receiveEffortCallback(subjugator_msgs::msg::ThrusterEfforts const &msg);
-    void receiveGazeboCallback(subjugator_msgs::msg::ThrusterEfforts const &msg);
+    void receiveGazeboCallback(gz::msgs::Double const &msg);
 
     // Thruster efforts storage - FLV = Front Left Vertical, BRH = Back Right Horizontal //
-    std::vector<float> thrusterEfforts_;
+    std::vector<std::string> thrusterNames{ flh, frh, blh, brh, flv, frv, blv, brv };
     float flh;
     float frh;
     float blh;

--- a/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
+++ b/src/subjugator/simulation/subjugator_gazebo/include/ThrusterBridge.hh
@@ -2,6 +2,7 @@
 #define THRUSTERBRIDGE__HH_
 
 #include <iostream>
+#include <vector>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -20,17 +21,14 @@
 #include <sdf/sdf.hh>
 
 // The .msg file is named ProcessedPing.msg (PascalCase) but #include must be the name in snake_case
-#include "../../../subjugator_msgs/msg/thruster_efforts.hpp"
 #include "subjugator_msgs/msg/thruster_efforts.hpp"
 
 using std::placeholders::_1;
 
 namespace thrusterBridge
 {
-class ThrusterBridge : public gz::sim::System,
-                       public gz::sim::ISystemConfigure,
-                       public gz::sim::ISystemPostUpdate,
-                       public rclcpp::Node
+class ThrusterBridge : public gz::sim::System, public gz::sim::ISystemConfigure, public gz::sim::ISystemPostUpdate
+
 {
   public:
     ThrusterBridge();

--- a/src/subjugator/simulation/subjugator_gazebo/src/ThrusterBridge.cc
+++ b/src/subjugator/simulation/subjugator_gazebo/src/ThrusterBridge.cc
@@ -1,0 +1,196 @@
+#include "Hydrophone.hh"
+#include "gz/plugin/Register.hh"  // For GZ_ADD_PLUGIN
+
+#include <gz/common/Console.hh>
+
+namespace hydrophone
+{
+
+Hydrophone::Hydrophone()
+{
+}
+
+Hydrophone::~Hydrophone()
+{
+}
+
+// FormatPinger() - Extract frequency and name //
+// This function takes in a string of the form "Pinger_1X_00000"
+// where X is a letter and 00000 is a 5 digit frequency
+// and extracts the frequency and name of the pinger from it.
+// It then stores the frequency and name in their respective vectors.
+void Hydrophone::FormatPinger(std::string &entityName)
+{
+    // Input string is of format: Pinger_1X_00000/Pinger_2X_00000
+    // Where X can be a value from A-Z and 00000 is a 5 digit frequency
+
+    // Split input string by underscore
+    size_t lastUnderscore = entityName.find_last_of('_');
+
+    // Extract the frequency after the last underscore and convert to an integer
+    std::string frequencyStr = entityName.substr(lastUnderscore + 1);
+    int frequency = std::stoi(frequencyStr);
+
+    // Extract the name of the Pinger
+    std::string pingerName = entityName.substr(0, lastUnderscore);
+
+    // Input Frequency and Name to the respective vectors
+    this->pingerFrequencies_.push_back(frequency);
+    this->pingerNames_.push_back(pingerName);
+
+    // Print the extracted frequency and name
+    // std::cout << "[Hydrophone] Extracted Frequency: " << frequency << std::endl;
+    // std::cout << "[Hydrophone] Extracted Name: " << pingerName << std::endl;
+}
+
+// Configure() - Gathers modelEntity and sdf at the start of the simulation //
+// which in this case is the World Entity and the World SDF respectively
+void Hydrophone::Configure(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
+                           gz::sim::EntityComponentManager &ecm, gz::sim::EventManager &eventMgr)
+{
+    // Gather necessary information for future GatherWorldInfo() call
+    this->modelEntity_ = entity;
+
+    // Create copy of the SDF element to perform modifications due to const
+    this->sdf_ = sdf->Clone();
+
+    // Initialize the ROS node and publisher
+    if (!rclcpp::ok())
+    {
+        rclcpp::init(0, nullptr);
+    }
+
+    // Create a ROS2 node for publishing
+    this->rosNode_ = std::make_shared<rclcpp::Node>("hydrophone_node");
+    this->pingPub_ = this->rosNode_->create_publisher<mil_msgs::msg::ProcessedPing>("/ping", 1);
+}
+
+// GatherWorldInfo() - At start of simulation scrape info from the worldSDF to get pinger info //
+// This function is called once at the start of the simulation
+// to gather all necessary information about pingers in the world
+// and store their poses and names for future use.
+// It also stores the hydrophone entity for future use.
+// This function is called only once to avoid unnecessary overhead.
+void Hydrophone::GatherWorldInfo(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
+                                 gz::sim::EntityComponentManager const &_ecm)
+{
+    // String to check for pinger names
+    std::string pingerPrefix = "Pinger_";
+
+    // Number of entities in the worldSDF
+    size_t entityCount = _ecm.EntityCount();
+    // std::cout << "Entity Count: " << entityCount << std::endl;
+
+    // Iterate through all entities and pass in Pose and Name components
+    // to check for pinger names and store their poses
+    _ecm.Each<gz::sim::components::Pose, gz::sim::components::Name>(
+        [&](gz::sim::Entity const &ent, gz::sim::components::Pose const *pose,
+            gz::sim::components::Name const *name) -> bool
+        {
+            // Check if pose and name components are valid
+            if (!pose || !name)
+            {
+                return true;
+            }
+
+            // Get current entity name
+            std::string entityName = name->Data();
+            // std::cout << "Entity Name: " << entityName << std::endl;
+
+            // If entity is hydrophone, store its entity
+            if (entityName == "hydrophone_sensor_link")
+            {
+                this->hydrophoneEntity_ = ent;
+            }
+
+            // Check if name starts with "Pinger_, i.e. if it is a pinger"
+            if (entityName.find(pingerPrefix) == 0)
+            {
+                // Store the pose of the pinger
+                this->pingerLocations_.push_back(pose->Data());
+
+                // std::cout << "Pinger Pose X: " << pose->Data().Pos().X() << std::endl;
+                // std::cout << "Pinger Pose Y: " << pose->Data().Pos().Y() << std::endl;
+                // std::cout << "Pinger Pose Z: " << pose->Data().Pos().Z() << std::endl;
+
+                // Format the name to extract frequency and Name
+                FormatPinger(entityName);
+            }
+
+            // Continue to next entity
+            return true;
+        }
+
+    );  // End of Each() function
+
+}  // End of GatherWorldInfo()
+
+// PostUpdate() - Called every simulation step to update pinger/hydrophone distances //
+// On first run, it calls GatherWorldInfo().
+// It spins the ROS Node, gets current hydrophone pose, and performs the following:
+// 1. Computes the difference vector between pinger and hydrophone poses
+// 2. Creates a ROS2 message with the difference vector, pinger frequency, and distance
+// 3. Publishes the message to the /ping topic
+void Hydrophone::PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComponentManager const &ecm)
+{
+    //  Check if the simulation is paused or running
+    if (info.paused)
+    {
+        return;
+    }
+
+    // Scrape worldSDF for pinger(s) info once
+    if (!worldGathered)
+    {
+        GatherWorldInfo(this->modelEntity_, this->sdf_, ecm);
+        worldGathered = true;
+    }
+
+    // Spin the ROS node to process incoming messages
+    rclcpp::spin_some(this->rosNode_);
+
+    // Get current pose of the Sub9 entity
+    auto hydrophoneComponent = ecm.Component<gz::sim::components::Pose>(this->hydrophoneEntity_);
+    if (hydrophoneComponent)
+    {
+        this->hydrophonePose_ = hydrophoneComponent->Data();
+        // std::cout << "[Hydrophone] Hydrophone Pose Updated: " << this->hydrophonePose_ << std::endl;
+    }
+
+    // Iterate over all pinger locations and compute difference vectors
+    int i = 0;
+    for (auto const &pingerPose : this->pingerLocations_)
+    {
+        // Compute difference vector (pinger - hydrophone)
+        gz::math::Vector3d diffVector = pingerPose.Pos() - hydrophonePose_.Pos();
+        this->pingerDiffs_.push_back(diffVector);
+
+        // Create ROS2 message
+        // Msg for Origin Direction Body
+        mil_msgs::msg::ProcessedPing msg;
+        msg.origin_direction_body.x = diffVector.X();
+        msg.origin_direction_body.y = diffVector.Y();
+        msg.origin_direction_body.z = diffVector.Z();
+
+        // Msg for Pinger Frequency
+        msg.frequency = this->pingerFrequencies_.at(i);
+
+        // Msg for Origin Distance
+        msg.origin_distance_m = diffVector.Length();
+
+        // Publish message
+        this->pingPub_->publish(msg);
+
+        // std::cout << "Pinger at [" << pingerPose.Pos() << "]" << std::endl
+        //           << "Difference vector: [" << diffVector << "]" << std::endl
+        //           << "Difference Length: [" << diffVector.Length() << "]" << std::endl
+        //           << "Frequency: [" << this->pingerFrequencies_.at(i) << "]" << std::endl;
+
+        i++;
+    }
+}
+
+}  // namespace hydrophone
+
+// Register plugin for Gazebo
+GZ_ADD_PLUGIN(hydrophone::Hydrophone, gz::sim::System, gz::sim::ISystemConfigure, gz::sim::ISystemPostUpdate)

--- a/src/subjugator/simulation/subjugator_gazebo/src/ThrusterBridge.cc
+++ b/src/subjugator/simulation/subjugator_gazebo/src/ThrusterBridge.cc
@@ -19,6 +19,9 @@ ThrusterBridge::~ThrusterBridge()
 void ThrusterBridge::Configure(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
                                gz::sim::EntityComponentManager &ecm, gz::sim::EventManager &eventMgr)
 {
+    std::cout << std::endl;
+    std::cout << "KEITHTHHHHHH" << std::endl;
+
     // Initialize the ROS node and publisher
     if (!rclcpp::ok())
     {
@@ -27,11 +30,16 @@ void ThrusterBridge::Configure(gz::sim::Entity const &entity, std::shared_ptr<sd
 
     // Create a ROS2 node for publishing
     this->rosNode_ = std::make_shared<rclcpp::Node>("thruster_to_gz");
-    this->thrusterSub_ = this->rosNode_->create_subscriber<subjugator_msgs::msg::ThrusterEfforts>(
-        "/thruster_efforts", 1, std::bind(&thrusterBridge::ThrusterBridge::receiveEffortCallback, this, _1);)
+    this->thrusterSub_ = this->rosNode_->create_subscription<subjugator_msgs::msg::ThrusterEfforts>(
+        "/thruster_efforts", 1,
+        std::bind(&thrusterBridge::ThrusterBridge::receiveEffortCallback, this, std::placeholders::_1));
+
+    // this->thruster_sub_ = this->node_->create_subscription<thruster_msgs::msg::ThrusterEfforts>(
+    //     "/thruster_efforts", 1,
+    //     std::bind(&ThrusterBridge::receiveEffortCallback, this, std::placeholders::_1));
 }
 
-void ThrusterBridge::receiveEffortCallback(mil_msgs::msg::ThrusterEfforts const &msg)
+void ThrusterBridge::receiveEffortCallback(subjugator_msgs::msg::ThrusterEfforts const &msg)
 {
     // Process the received thruster efforts message
     std::cout << "[ThrusterBridge] Received Thruster Efforts: " << std::endl;

--- a/src/subjugator/simulation/subjugator_gazebo/src/ThrusterBridge.cc
+++ b/src/subjugator/simulation/subjugator_gazebo/src/ThrusterBridge.cc
@@ -1,59 +1,24 @@
-#include "Hydrophone.hh"
+#include "ThrusterBridge.hh"
+
 #include "gz/plugin/Register.hh"  // For GZ_ADD_PLUGIN
 
 #include <gz/common/Console.hh>
 
-namespace hydrophone
+namespace thrusterBridge
 {
 
-Hydrophone::Hydrophone()
-{
-}
-
-Hydrophone::~Hydrophone()
+ThrusterBridge::ThrusterBridge()
 {
 }
 
-// FormatPinger() - Extract frequency and name //
-// This function takes in a string of the form "Pinger_1X_00000"
-// where X is a letter and 00000 is a 5 digit frequency
-// and extracts the frequency and name of the pinger from it.
-// It then stores the frequency and name in their respective vectors.
-void Hydrophone::FormatPinger(std::string &entityName)
+ThrusterBridge::~ThrusterBridge()
 {
-    // Input string is of format: Pinger_1X_00000/Pinger_2X_00000
-    // Where X can be a value from A-Z and 00000 is a 5 digit frequency
-
-    // Split input string by underscore
-    size_t lastUnderscore = entityName.find_last_of('_');
-
-    // Extract the frequency after the last underscore and convert to an integer
-    std::string frequencyStr = entityName.substr(lastUnderscore + 1);
-    int frequency = std::stoi(frequencyStr);
-
-    // Extract the name of the Pinger
-    std::string pingerName = entityName.substr(0, lastUnderscore);
-
-    // Input Frequency and Name to the respective vectors
-    this->pingerFrequencies_.push_back(frequency);
-    this->pingerNames_.push_back(pingerName);
-
-    // Print the extracted frequency and name
-    // std::cout << "[Hydrophone] Extracted Frequency: " << frequency << std::endl;
-    // std::cout << "[Hydrophone] Extracted Name: " << pingerName << std::endl;
 }
 
-// Configure() - Gathers modelEntity and sdf at the start of the simulation //
-// which in this case is the World Entity and the World SDF respectively
-void Hydrophone::Configure(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
-                           gz::sim::EntityComponentManager &ecm, gz::sim::EventManager &eventMgr)
+// Configure() -  //
+void ThrusterBridge::Configure(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
+                               gz::sim::EntityComponentManager &ecm, gz::sim::EventManager &eventMgr)
 {
-    // Gather necessary information for future GatherWorldInfo() call
-    this->modelEntity_ = entity;
-
-    // Create copy of the SDF element to perform modifications due to const
-    this->sdf_ = sdf->Clone();
-
     // Initialize the ROS node and publisher
     if (!rclcpp::ok())
     {
@@ -61,77 +26,28 @@ void Hydrophone::Configure(gz::sim::Entity const &entity, std::shared_ptr<sdf::E
     }
 
     // Create a ROS2 node for publishing
-    this->rosNode_ = std::make_shared<rclcpp::Node>("hydrophone_node");
-    this->pingPub_ = this->rosNode_->create_publisher<mil_msgs::msg::ProcessedPing>("/ping", 1);
+    this->rosNode_ = std::make_shared<rclcpp::Node>("thruster_to_gz");
+    this->thrusterSub_ = this->rosNode_->create_subscriber<subjugator_msgs::msg::ThrusterEfforts>(
+        "/thruster_efforts", 1, std::bind(&thrusterBridge::ThrusterBridge::receiveEffortCallback, this, _1);)
 }
 
-// GatherWorldInfo() - At start of simulation scrape info from the worldSDF to get pinger info //
-// This function is called once at the start of the simulation
-// to gather all necessary information about pingers in the world
-// and store their poses and names for future use.
-// It also stores the hydrophone entity for future use.
-// This function is called only once to avoid unnecessary overhead.
-void Hydrophone::GatherWorldInfo(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
-                                 gz::sim::EntityComponentManager const &_ecm)
+void ThrusterBridge::receiveEffortCallback(mil_msgs::msg::ThrusterEfforts const &msg)
 {
-    // String to check for pinger names
-    std::string pingerPrefix = "Pinger_";
+    // Process the received thruster efforts message
+    std::cout << "[ThrusterBridge] Received Thruster Efforts: " << std::endl;
 
-    // Number of entities in the worldSDF
-    size_t entityCount = _ecm.EntityCount();
-    // std::cout << "Entity Count: " << entityCount << std::endl;
+    flh = msg.thrust_flh;
+    frh = msg.thrust_frh;
+    blh = msg.thrust_blh;
+    brh = msg.thrust_brh;
+    flv = msg.thrust_flv;
+    frv = msg.thrust_frv;
+    blv = msg.thrust_blv;
+    brv = msg.thrust_brv;
+}
 
-    // Iterate through all entities and pass in Pose and Name components
-    // to check for pinger names and store their poses
-    _ecm.Each<gz::sim::components::Pose, gz::sim::components::Name>(
-        [&](gz::sim::Entity const &ent, gz::sim::components::Pose const *pose,
-            gz::sim::components::Name const *name) -> bool
-        {
-            // Check if pose and name components are valid
-            if (!pose || !name)
-            {
-                return true;
-            }
-
-            // Get current entity name
-            std::string entityName = name->Data();
-            // std::cout << "Entity Name: " << entityName << std::endl;
-
-            // If entity is hydrophone, store its entity
-            if (entityName == "hydrophone_sensor_link")
-            {
-                this->hydrophoneEntity_ = ent;
-            }
-
-            // Check if name starts with "Pinger_, i.e. if it is a pinger"
-            if (entityName.find(pingerPrefix) == 0)
-            {
-                // Store the pose of the pinger
-                this->pingerLocations_.push_back(pose->Data());
-
-                // std::cout << "Pinger Pose X: " << pose->Data().Pos().X() << std::endl;
-                // std::cout << "Pinger Pose Y: " << pose->Data().Pos().Y() << std::endl;
-                // std::cout << "Pinger Pose Z: " << pose->Data().Pos().Z() << std::endl;
-
-                // Format the name to extract frequency and Name
-                FormatPinger(entityName);
-            }
-
-            // Continue to next entity
-            return true;
-        }
-
-    );  // End of Each() function
-
-}  // End of GatherWorldInfo()
-
-// PostUpdate() - Called every simulation step to update pinger/hydrophone distances //
-// On first run, it calls GatherWorldInfo().
-// It spins the ROS Node, gets current hydrophone pose, and performs the following:
-// 1. Computes the difference vector between pinger and hydrophone poses
-// 2. Creates a ROS2 message with the difference vector, pinger frequency, and distance
-// 3. Publishes the message to the /ping topic
-void Hydrophone::PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComponentManager const &ecm)
+// PostUpdate() -  //
+void ThrusterBridge::PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComponentManager const &ecm)
 {
     //  Check if the simulation is paused or running
     if (info.paused)
@@ -139,58 +55,11 @@ void Hydrophone::PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComp
         return;
     }
 
-    // Scrape worldSDF for pinger(s) info once
-    if (!worldGathered)
-    {
-        GatherWorldInfo(this->modelEntity_, this->sdf_, ecm);
-        worldGathered = true;
-    }
-
     // Spin the ROS node to process incoming messages
     rclcpp::spin_some(this->rosNode_);
-
-    // Get current pose of the Sub9 entity
-    auto hydrophoneComponent = ecm.Component<gz::sim::components::Pose>(this->hydrophoneEntity_);
-    if (hydrophoneComponent)
-    {
-        this->hydrophonePose_ = hydrophoneComponent->Data();
-        // std::cout << "[Hydrophone] Hydrophone Pose Updated: " << this->hydrophonePose_ << std::endl;
-    }
-
-    // Iterate over all pinger locations and compute difference vectors
-    int i = 0;
-    for (auto const &pingerPose : this->pingerLocations_)
-    {
-        // Compute difference vector (pinger - hydrophone)
-        gz::math::Vector3d diffVector = pingerPose.Pos() - hydrophonePose_.Pos();
-        this->pingerDiffs_.push_back(diffVector);
-
-        // Create ROS2 message
-        // Msg for Origin Direction Body
-        mil_msgs::msg::ProcessedPing msg;
-        msg.origin_direction_body.x = diffVector.X();
-        msg.origin_direction_body.y = diffVector.Y();
-        msg.origin_direction_body.z = diffVector.Z();
-
-        // Msg for Pinger Frequency
-        msg.frequency = this->pingerFrequencies_.at(i);
-
-        // Msg for Origin Distance
-        msg.origin_distance_m = diffVector.Length();
-
-        // Publish message
-        this->pingPub_->publish(msg);
-
-        // std::cout << "Pinger at [" << pingerPose.Pos() << "]" << std::endl
-        //           << "Difference vector: [" << diffVector << "]" << std::endl
-        //           << "Difference Length: [" << diffVector.Length() << "]" << std::endl
-        //           << "Frequency: [" << this->pingerFrequencies_.at(i) << "]" << std::endl;
-
-        i++;
-    }
 }
 
-}  // namespace hydrophone
+}  // namespace thrusterBridge
 
 // Register plugin for Gazebo
-GZ_ADD_PLUGIN(hydrophone::Hydrophone, gz::sim::System, gz::sim::ISystemConfigure, gz::sim::ISystemPostUpdate)
+GZ_ADD_PLUGIN(thrusterBridge::ThrusterBridge, gz::sim::System, gz::sim::ISystemConfigure, gz::sim::ISystemPostUpdate)

--- a/src/subjugator/simulation/subjugator_gazebo/src/ThrusterBridge.cc
+++ b/src/subjugator/simulation/subjugator_gazebo/src/ThrusterBridge.cc
@@ -35,11 +35,10 @@ void ThrusterBridge::Configure(gz::sim::Entity const &entity, std::shared_ptr<sd
         "/thruster_efforts", 1, std::bind(&thrusterBridge::ThrusterBridge::receiveEffortCallback, this, _1));
 
     // Gazebo transport node
-    // change to proper gz::msgs:
-    std::function<void(subjugator_msgs::msg::ThrusterEfforts const &)> callback =
+    std::function<void(gz::msgs::Double const &)> callback =
         std::bind(&ThrusterBridge::receiveGazeboCallback, this, _1);
 
-    gz_node.Subscribe("/thruster_efforts", callback);
+    gz_node.Advertise("/model/FLH/joint/FLH_dir_joint/cmd_thrust", callback);
 }
 
 void ThrusterBridge::receiveEffortCallback(subjugator_msgs::msg::ThrusterEfforts const &msg)
@@ -55,21 +54,31 @@ void ThrusterBridge::receiveEffortCallback(subjugator_msgs::msg::ThrusterEfforts
     frv = msg.thrust_frv;
     blv = msg.thrust_blv;
     brv = msg.thrust_brv;
+
+    for (int i = 0; i < 8; i++)
+    {
+        std::string topicName = "/model/ " + thrusterNames[i] + "/joint/" + thrusterNames[i] + "_dir_joint/cmd_thrust";
+        gz_node.Advertise(topicName, )
+    }
+
+    std::cout << "KEITHING IT" << std::endl;
 }
 
-void ThrusterBridge::receiveGazeboCallback(subjugator_msgs::msg::ThrusterEfforts const &msg)
+void ThrusterBridge::receiveGazeboCallback(gz::msgs::Double const &msg)
 {
     // Process the received thruster efforts message
-    std::cout << "[ThrusterBridge] Received Thruster Efforts: " << std::endl;
+    std::cout << "[Gazebo Node] Received Thruster Efforts: " << std::endl;
 
-    flh = msg.thrust_flh;
-    frh = msg.thrust_frh;
-    blh = msg.thrust_blh;
-    brh = msg.thrust_brh;
-    flv = msg.thrust_flv;
-    frv = msg.thrust_frv;
-    blv = msg.thrust_blv;
-    brv = msg.thrust_brv;
+    msg = flh
+
+    // flh = msg.thrust_flh;
+    // frh = msg.thrust_frh;
+    // blh = msg.thrust_blh;
+    // brh = msg.thrust_brh;
+    // flv = msg.thrust_flv;
+    // frv = msg.thrust_frv;
+    // blv = msg.thrust_blv;
+    // brv = msg.thrust_brv;
 }
 
 // PostUpdate() -  //

--- a/src/subjugator/simulation/subjugator_gazebo/worlds/robosub_2024.world
+++ b/src/subjugator/simulation/subjugator_gazebo/worlds/robosub_2024.world
@@ -45,6 +45,11 @@
                 name="hydrophone::Hydrophone">
                 <topic>${name}</topic>
             </plugin>
+            <plugin
+                filename="ThrusterBridge"
+                name="thruster_bridge::ThrusterBridge">
+                <topic>${name}</topic>
+            </plugin>
 
             <!-- Buoyancy Plugin -->
             <!--

--- a/src/subjugator/simulation/subjugator_gazebo/worlds/robosub_2024.world
+++ b/src/subjugator/simulation/subjugator_gazebo/worlds/robosub_2024.world
@@ -45,11 +45,6 @@
                 name="hydrophone::Hydrophone">
                 <topic>${name}</topic>
             </plugin>
-            <plugin
-                filename="ThrusterBridge"
-                name="thruster_bridge::ThrusterBridge">
-                <topic>${name}</topic>
-            </plugin>
 
             <!-- Buoyancy Plugin -->
             <!--

--- a/src/subjugator/subjugator_msgs/package.xml
+++ b/src/subjugator/subjugator_msgs/package.xml
@@ -11,9 +11,15 @@
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
This is a plugin for Gazebo that subscribes to the ROS2 topic "thruster_efforts" and then splits the message up and send it to each of the 8 Gazebo topic such as /model/FRV/joint/FRV_dir_joint/cmd_thrust. 

I tested the code with output/echo messages from both the ROS and Gazebo topic(s) and it seemed to work for me even when moving the thrusters through a ROS publish command.

Sorry this took so long lol