### PR TITLE
Subjugator keyboard control (again)

### DIFF
--- a/src/subjugator/command/subjugator_keyboard_control/CMakeLists.txt
+++ b/src/subjugator/command/subjugator_keyboard_control/CMakeLists.txt
@@ -18,9 +18,7 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
   PRIVATE ${SDL2_INCLUDE_DIRS})
-target_link_libraries(subjugator_keyboard_control
-        ${SDL2_LIBRARIES}
-)
+target_link_libraries(subjugator_keyboard_control ${SDL2_LIBRARIES})
 target_compile_features(subjugator_keyboard_control PUBLIC c_std_99 cxx_std_17)
 
 ament_target_dependencies(subjugator_keyboard_control rclcpp geometry_msgs)

--- a/src/subjugator/command/subjugator_keyboard_control/CMakeLists.txt
+++ b/src/subjugator/command/subjugator_keyboard_control/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(SDL2 REQUIRED)
 
 add_executable(subjugator_keyboard_control src/node.cpp
                                            src/SubjugatorKeyboardControl.cpp)
@@ -15,7 +16,11 @@ add_executable(subjugator_keyboard_control src/node.cpp
 target_include_directories(
   subjugator_keyboard_control
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-         $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+         $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+  PRIVATE ${SDL2_INCLUDE_DIRS})
+target_link_libraries(subjugator_keyboard_control
+        ${SDL2_LIBRARIES}
+)
 target_compile_features(subjugator_keyboard_control PUBLIC c_std_99 cxx_std_17)
 
 ament_target_dependencies(subjugator_keyboard_control rclcpp geometry_msgs)

--- a/src/subjugator/command/subjugator_keyboard_control/include/subjugator_keyboard_control/SubjugatorKeyboardControl.h
+++ b/src/subjugator/command/subjugator_keyboard_control/include/subjugator_keyboard_control/SubjugatorKeyboardControl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <SDL2/SDL.h>
 #include <fcntl.h>
 #include <termios.h>
 #include <unistd.h>
@@ -10,8 +11,8 @@
 #include <thread>
 
 #include "rclcpp/rclcpp.hpp"
+
 #include "geometry_msgs/msg/wrench.hpp"
-#include <SDL2/SDL.h>
 
 // May be used elsewhere if similar logic?
 struct KeyState
@@ -33,17 +34,16 @@ class SubjugatorKeyboardControl final : public rclcpp::Node
     SubjugatorKeyboardControl();
     ~SubjugatorKeyboardControl() override;
 
-
   private:
-    // Hiden window for key events
-    SDL_Window* window_{nullptr};
+    // Hidden window for key events
+    SDL_Window* window_{ nullptr };
 
     // ROS Publisher
     rclcpp::Publisher<geometry_msgs::msg::Wrench>::SharedPtr publisher_;
 
     std::atomic<double> force_x_, force_y_, force_z_;
     std::atomic<double> torque_x_, torque_y_, torque_z_;
-    double base_linear_, base_angular_; // Base speed
+    double base_linear_, base_angular_;  // Base speed
 
     // Multithreading
     std::thread keyboard_thread_;
@@ -52,7 +52,7 @@ class SubjugatorKeyboardControl final : public rclcpp::Node
 
     // For handling raw mode terminal
     termios old_tio_{};
-    bool termios_initialized_{false};
+    bool termios_initialized_{ false };
 
     void initTerminal();
     void restoreTerminal() const;

--- a/src/subjugator/command/subjugator_keyboard_control/include/subjugator_keyboard_control/SubjugatorKeyboardControl.h
+++ b/src/subjugator/command/subjugator_keyboard_control/include/subjugator_keyboard_control/SubjugatorKeyboardControl.h
@@ -10,8 +10,8 @@
 #include <thread>
 
 #include "rclcpp/rclcpp.hpp"
-
 #include "geometry_msgs/msg/wrench.hpp"
+#include <SDL2/SDL.h>
 
 // May be used elsewhere if similar logic?
 struct KeyState
@@ -33,18 +33,30 @@ class SubjugatorKeyboardControl final : public rclcpp::Node
     SubjugatorKeyboardControl();
     ~SubjugatorKeyboardControl() override;
 
+
   private:
+    // Hiden window for key events
+    SDL_Window* window_{nullptr};
+
+    // ROS Publisher
     rclcpp::Publisher<geometry_msgs::msg::Wrench>::SharedPtr publisher_;
+
     std::atomic<double> force_x_, force_y_, force_z_;
     std::atomic<double> torque_x_, torque_y_, torque_z_;
-    double base_linear_, base_angular_;
+    double base_linear_, base_angular_; // Base speed
+
+    // Multithreading
     std::thread keyboard_thread_;
     std::thread publisher_thread_;
     std::atomic<bool> running_;
-    termios old_terminal_settings_{};
-    bool terminal_initialized_{ false };
+
+    // For handling raw mode terminal
+    termios old_tio_{};
+    bool termios_initialized_{false};
+
     void initTerminal();
     void restoreTerminal() const;
+
     void keyboardLoop();
     void publishLoop() const;
 };

--- a/src/subjugator/command/subjugator_keyboard_control/package.xml
+++ b/src/subjugator/command/subjugator_keyboard_control/package.xml
@@ -9,6 +9,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libsdl2-dev</build_depend>
+  <exec_depend>libsdl2-dev</exec_depend>
+
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <export>

--- a/src/subjugator/command/subjugator_keyboard_control/src/SubjugatorKeyboardControl.cpp
+++ b/src/subjugator/command/subjugator_keyboard_control/src/SubjugatorKeyboardControl.cpp
@@ -61,45 +61,48 @@ SubjugatorKeyboardControl::~SubjugatorKeyboardControl()
 void SubjugatorKeyboardControl::initTerminal()
 {
     // Initialize SDL video for real key events
-    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+    if (SDL_Init(SDL_INIT_VIDEO) != 0)
+    {
         RCLCPP_ERROR(get_logger(), "SDL_Init Error: %s", SDL_GetError());
         return;
     }
-    window_ = SDL_CreateWindow(
-        "subj_ctl",
-        SDL_WINDOWPOS_CENTERED,
-        SDL_WINDOWPOS_CENTERED,
-        600, 400,
-        SDL_WINDOW_SHOWN               // <-- must be SHOWN, not HIDDEN
+    window_ = SDL_CreateWindow("subj_ctl", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 600, 400,
+                               SDL_WINDOW_SHOWN  // <-- must be SHOWN, not HIDDEN
     );
     SDL_RaiseWindow(window_);
 
-
     // Enable raw terminal mode to disable echo and line buffering
-    if (tcgetattr(STDIN_FILENO, &old_tio_) == 0) {
+    if (tcgetattr(STDIN_FILENO, &old_tio_) == 0)
+    {
         termios new_tio = old_tio_;
-        new_tio.c_lflag &= ~(ICANON | ECHO);    // non-canonical, no echo
-        new_tio.c_cc[VMIN] = 0;                 // non-blocking read
-        new_tio.c_cc[VTIME] = 1;                // 0.1s timeout
-        if (tcsetattr(STDIN_FILENO, TCSANOW, &new_tio) == 0) {
+        new_tio.c_lflag &= ~(ICANON | ECHO);  // non-canonical, no echo
+        new_tio.c_cc[VMIN] = 0;               // non-blocking read
+        new_tio.c_cc[VTIME] = 1;              // 0.1s timeout
+        if (tcsetattr(STDIN_FILENO, TCSANOW, &new_tio) == 0)
+        {
             termios_initialized_ = true;
-        } else {
+        }
+        else
+        {
             RCLCPP_WARN(get_logger(), "Failed to set raw terminal mode");
         }
-    } else {
+    }
+    else
+    {
         RCLCPP_WARN(get_logger(), "Failed to get terminal attributes");
     }
 }
 
-
 void SubjugatorKeyboardControl::restoreTerminal() const
 {
-    if (window_) {
+    if (window_)
+    {
         SDL_DestroyWindow(window_);
     }
     SDL_Quit();
 
-    if (termios_initialized_) {
+    if (termios_initialized_)
+    {
         tcsetattr(STDIN_FILENO, TCSANOW, &old_tio_);
     }
 }
@@ -129,40 +132,110 @@ void SubjugatorKeyboardControl::keyboardLoop()
     {
         auto now = steady_clock::now();
 
-        while (SDL_PollEvent(&e)) {
-            if (e.type == SDL_KEYDOWN && !e.key.repeat) {
-                switch (e.key.keysym.sym) {
-                    case SDLK_w:     key_w.pressed = true;     key_w.last_time = now; break;
-                    case SDLK_s:     key_s.pressed = true;     key_s.last_time = now; break;
-                    case SDLK_a:     key_a.pressed = true;     key_a.last_time = now; break;
-                    case SDLK_d:     key_d.pressed = true;     key_d.last_time = now; break;
-                    case SDLK_e:     key_e.pressed = true;     key_e.last_time = now; break;
-                    case SDLK_r:     key_r.pressed = true;     key_r.last_time = now; break;
-                    case SDLK_x:     key_x.pressed = true;     key_x.last_time = now; break;
-                    case SDLK_z:     key_z.pressed = true;     key_z.last_time = now; break;
-                    case SDLK_UP:    arrow_up.pressed = true;    arrow_up.last_time = now;    break;
-                    case SDLK_DOWN:  arrow_down.pressed = true;  arrow_down.last_time = now;  break;
-                    case SDLK_RIGHT: arrow_right.pressed = true; arrow_right.last_time = now; break;
-                    case SDLK_LEFT:  arrow_left.pressed = true;  arrow_left.last_time = now;  break;
-                    case SDLK_q:     running_ = false; rclcpp::shutdown();                   break;
-                    default:        break;
+        while (SDL_PollEvent(&e))
+        {
+            if (e.type == SDL_KEYDOWN && !e.key.repeat)
+            {
+                switch (e.key.keysym.sym)
+                {
+                    case SDLK_w:
+                        key_w.pressed = true;
+                        key_w.last_time = now;
+                        break;
+                    case SDLK_s:
+                        key_s.pressed = true;
+                        key_s.last_time = now;
+                        break;
+                    case SDLK_a:
+                        key_a.pressed = true;
+                        key_a.last_time = now;
+                        break;
+                    case SDLK_d:
+                        key_d.pressed = true;
+                        key_d.last_time = now;
+                        break;
+                    case SDLK_e:
+                        key_e.pressed = true;
+                        key_e.last_time = now;
+                        break;
+                    case SDLK_r:
+                        key_r.pressed = true;
+                        key_r.last_time = now;
+                        break;
+                    case SDLK_x:
+                        key_x.pressed = true;
+                        key_x.last_time = now;
+                        break;
+                    case SDLK_z:
+                        key_z.pressed = true;
+                        key_z.last_time = now;
+                        break;
+                    case SDLK_UP:
+                        arrow_up.pressed = true;
+                        arrow_up.last_time = now;
+                        break;
+                    case SDLK_DOWN:
+                        arrow_down.pressed = true;
+                        arrow_down.last_time = now;
+                        break;
+                    case SDLK_RIGHT:
+                        arrow_right.pressed = true;
+                        arrow_right.last_time = now;
+                        break;
+                    case SDLK_LEFT:
+                        arrow_left.pressed = true;
+                        arrow_left.last_time = now;
+                        break;
+                    case SDLK_q:
+                        running_ = false;
+                        rclcpp::shutdown();
+                        break;
+                    default:
+                        break;
                 }
             }
-            else if (e.type == SDL_KEYUP) {
-                switch (e.key.keysym.sym) {
-                    case SDLK_w:   key_w.pressed = false;   break;
-                    case SDLK_s:   key_s.pressed = false;   break;
-                    case SDLK_a:   key_a.pressed = false;   break;
-                    case SDLK_d:   key_d.pressed = false;   break;
-                    case SDLK_e:   key_e.pressed = false;   break;
-                    case SDLK_r:   key_r.pressed = false;   break;
-                    case SDLK_x:   key_x.pressed = false;   break;
-                    case SDLK_z:   key_z.pressed = false;   break;
-                    case SDLK_UP:    arrow_up.pressed = false;    break;
-                    case SDLK_DOWN:  arrow_down.pressed = false;  break;
-                    case SDLK_RIGHT: arrow_right.pressed = false; break;
-                    case SDLK_LEFT:  arrow_left.pressed = false;  break;
-                    default:          break;
+            else if (e.type == SDL_KEYUP)
+            {
+                switch (e.key.keysym.sym)
+                {
+                    case SDLK_w:
+                        key_w.pressed = false;
+                        break;
+                    case SDLK_s:
+                        key_s.pressed = false;
+                        break;
+                    case SDLK_a:
+                        key_a.pressed = false;
+                        break;
+                    case SDLK_d:
+                        key_d.pressed = false;
+                        break;
+                    case SDLK_e:
+                        key_e.pressed = false;
+                        break;
+                    case SDLK_r:
+                        key_r.pressed = false;
+                        break;
+                    case SDLK_x:
+                        key_x.pressed = false;
+                        break;
+                    case SDLK_z:
+                        key_z.pressed = false;
+                        break;
+                    case SDLK_UP:
+                        arrow_up.pressed = false;
+                        break;
+                    case SDLK_DOWN:
+                        arrow_down.pressed = false;
+                        break;
+                    case SDLK_RIGHT:
+                        arrow_right.pressed = false;
+                        break;
+                    case SDLK_LEFT:
+                        arrow_left.pressed = false;
+                        break;
+                    default:
+                        break;
                 }
             }
         }


### PR DESCRIPTION
Fix the keyboard timing issue by using SDL library.

Saw @tripAarush's pr but I'm pretty sure the only way to solve the zero-gap issue is to have a library that emits actual keyup/keydown events, instead of poll() + getchar() + inferring key released by no input.

Only downside is that a separate terminal is required.