### PR TITLE
add colcon meta for ftxui to build it as a shared library

### DIFF
--- a/colcon.meta
+++ b/colcon.meta
@@ -1,0 +1,9 @@
+{
+  "names": {
+    "ftxui": {
+      "cmake-args": [
+        "-DBUILD_SHARED_LIBS=ON"
+      ]
+    }
+  }
+}

--- a/src/mil_common/mil_preflight/CMakeLists.txt
+++ b/src/mil_common/mil_preflight/CMakeLists.txt
@@ -11,15 +11,7 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(subjugator_msgs REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread chrono filesystem system)
-
-set(_OLD_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-set(FTXUI_BINARY_DIR ${CMAKE_BINARY_DIR}/ftxui-build)
-set(FTXUI_SOURCE_DIR ${CMAKE_SOURCE_DIR}/../../../ext/FTXUI)
-add_subdirectory(${FTXUI_SOURCE_DIR} ${FTXUI_BINARY_DIR})
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ${_OLD_CMAKE_POSITION_INDEPENDENT_CODE})
+find_package(ftxui REQUIRED)
 
 add_executable(${PROJECT_NAME} src/frontend.cpp)
 include_directories(include ${ftxui_SOURCE_DIR}/include ${Boost_INCLUDE_DIRS})

--- a/src/mil_common/mil_preflight/package.xml
+++ b/src/mil_common/mil_preflight/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>ftxui</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>subjugator_msgs</depend>


### PR DESCRIPTION
Previously, I used `add_subdirectory` in CMake to build the ftxui library separately, as the `-fPIC` option was needed to link it into a shared library. However, this approach caused ftxui to be built twice because colcon could also detect and build it.
To resolve this, I added colcon metadata (colcon.meta) for ftxui to configure it as a shared library. Now, I use `find_package` to locate ftxui, and OnlineBagger will link against it to display a progress bar.