### PR TITLE
Added front cam panel to subjugator rviz

### DIFF
--- a/src/subjugator/subjugator_bringup/config/subjugator.rviz
+++ b/src/subjugator/subjugator_bringup/config/subjugator.rviz
@@ -167,6 +167,20 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
+        Value: /front_cam/image_raw
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
         Value: /down_cam/image_raw
       Value: true
     - Class: rviz_default_plugins/TF


### PR DESCRIPTION
I added an image panel to the rviz config, so that now it shows the subjugator front_cam too, whereas before it merely showed the down_cam.

![image](https://github.com/user-attachments/assets/c37f3b0d-e14b-4b3a-b792-61d99f083769)


Closes #163