### PR TITLE
hydrophone readings now in base_link

### DIFF
--- a/src/mil_common/mil_passive_sonar/scripts/ping_publisher.py
+++ b/src/mil_common/mil_passive_sonar/scripts/ping_publisher.py
@@ -33,10 +33,10 @@ def main():
                 ping_msg.origin_direction_body.x = float(
                     json_data["origin_direction_body"][0],
                 )
-                ping_msg.origin_direction_body.y = float(
+                ping_msg.origin_direction_body.y = -float(
                     json_data["origin_direction_body"][1],
                 )
-                ping_msg.origin_direction_body.z = float(
+                ping_msg.origin_direction_body.z = -float(
                     json_data["origin_direction_body"][2],
                 )
                 ping_msg.frequency = int(json_data["frequency_Hz"])


### PR DESCRIPTION
before they were
X,Y,Z = forward, right, down
now they are
X,Y,Z = forward, left, up (consistent with rest of sub)