### PR TITLE
Carter marble dropper

### DIFF
--- a/src/subjugator/command/subjugator_keyboard_control/src/SubjugatorKeyboardControl.cpp
+++ b/src/subjugator/command/subjugator_keyboard_control/src/SubjugatorKeyboardControl.cpp
@@ -21,6 +21,8 @@ SubjugatorKeyboardControl::SubjugatorKeyboardControl()
   , running_(true)
 {
     publisher_ = this->create_publisher<geometry_msgs::msg::Wrench>("cmd_wrench", PUBLISH_RATE);
+    // Add publisher for keypress events
+    keypress_publisher_ = this->create_publisher<std_msgs::msg::String>("keyboard/keypress", 10);
     this->declare_parameter("linear_speed", 100.0);
     this->declare_parameter("angular_speed", 100.0);
     base_linear_ = this->get_parameter("linear_speed").as_double();

--- a/src/subjugator/simulation/subjugator_gazebo/include/MarbleDropper.hh
+++ b/src/subjugator/simulation/subjugator_gazebo/include/MarbleDropper.hh
@@ -33,10 +33,7 @@
 
 namespace marble_dropper
 {
-class MarbleDropper : public gz::sim::System,
-                      public gz::sim::ISystemConfigure,
-                      public gz::sim::ISystemPreUpdate,
-                      public gz::sim::ISystemPostUpdate
+class MarbleDropper : public gz::sim::System, public gz::sim::ISystemConfigure, public gz::sim::ISystemPostUpdate
 {
   public:
     MarbleDropper();
@@ -45,9 +42,6 @@ class MarbleDropper : public gz::sim::System,
     // Configure() - Gathers Info at the start of the simulation //
     void Configure(gz::sim::Entity const &entity, std::shared_ptr<sdf::Element const> const &sdf,
                    gz::sim::EntityComponentManager &ecm, gz::sim::EventManager &eventMgr) override;
-
-    // System PreUpdate - Called every simulation step before physics //
-    void PreUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComponentManager &ecm) override;
 
     // System PostUpdate - Called every simulation step to update pinger/marble_dropper distances //
     void PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComponentManager const &ecm) override;

--- a/src/subjugator/simulation/subjugator_gazebo/src/MarbleDropper.cc
+++ b/src/subjugator/simulation/subjugator_gazebo/src/MarbleDropper.cc
@@ -55,11 +55,6 @@ void MarbleDropper::KeypressCallback(std_msgs::msg::String::SharedPtr const msg)
     }
 }
 
-void MarbleDropper::PreUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityComponentManager &ecm)
-{
-    // Unnecessary if not adding velocity to marble(s)
-}
-
 void MarbleDropper::SpawnMarble(std::string const &worldName, std::string const &sdfPath)
 {
     // Load SDF file as string
@@ -102,7 +97,7 @@ void MarbleDropper::SpawnMarble(std::string const &worldName, std::string const 
 
     // Set the pose to X, Y, Z, and roll, pitch, yaw
     // -0.5 offset in Z to not hit sub9
-    gz::msgs::Set(factoryMsg.mutable_pose(), gz::math::Pose3d(sub9_pose.X(), sub9_pose.Y(), sub9_pose.Z() - 0.5,
+    gz::msgs::Set(factoryMsg.mutable_pose(), gz::math::Pose3d(sub9_pose.X(), sub9_pose.Y() + 0.5, sub9_pose.Z() - 0.25,
                                                               sub9_pose.Roll(), sub9_pose.Pitch(), sub9_pose.Yaw()));
 
     // Send the request to create model in .world
@@ -155,6 +150,9 @@ void MarbleDropper::PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityC
             std::string removeService = "/world/" + worldName + "/remove";
             node.Request(removeService, removeMsg, timeout, reply, result);
 
+            std::cout << "[MarbleDropper] Removed marble: " << spawnedMarbIter->first << " after " << timeElapsed
+                      << " seconds." << std::endl;
+
             // Clean up tracking
             marbleModelNames.erase(spawnedMarbIter->first);
             spawnedMarbIter = marbleSpawnTimes.erase(spawnedMarbIter);
@@ -178,5 +176,4 @@ void MarbleDropper::PostUpdate(gz::sim::UpdateInfo const &info, gz::sim::EntityC
 }  // namespace marble_dropper
 
 // Register plugin for Gazebo
-GZ_ADD_PLUGIN(marble_dropper::MarbleDropper, gz::sim::System, gz::sim::ISystemConfigure, gz::sim::ISystemPostUpdate,
-              gz::sim::ISystemPreUpdate)
+GZ_ADD_PLUGIN(marble_dropper::MarbleDropper, gz::sim::System, gz::sim::ISystemConfigure, gz::sim::ISystemPostUpdate)


### PR DESCRIPTION
I added a Gazebo Plugin so that when running Subjugator Keyboard Controller is running the user can press 'm' to spawn a marble underneath the sub that despawns after 8 seconds. 

Only 2 marbles can spawn. To spawn more, the user must reset the Gazebo simulation which can be done within the Gz GUI.