### PR TITLE
Use TCP for milwiki healthcheck

### DIFF
--- a/.github/workflows/healthcheck.yaml
+++ b/.github/workflows/healthcheck.yaml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: milwiki
         run: |
-          ping -c 1 milwiki.cbrxyz.com &> /dev/null
+          wget milwiki.cbrxyz.com -O /dev/null &> /dev/null
       - name: mil website
         run: |
           ping -c 1 mil.ufl.edu &> /dev/null


### PR DESCRIPTION
`ping milwiki.cbrxyz.com` has no response, either enable pings on the host or switch to a working liveness check