### PR TITLE
fixed blubjugator localization in sim

### DIFF
--- a/src/subjugator/simulation/subjugator_description/urdf/sub9_sim.urdf.xacro
+++ b/src/subjugator/simulation/subjugator_description/urdf/sub9_sim.urdf.xacro
@@ -113,7 +113,7 @@
   <joint name="base_to_localization" type="fixed">
     <parent link="localization_center"/>
     <child link="base_link"/>
-    <origin xyz="-0.354 0 0" rpy="0 0 0"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
   </joint>
 
   <!-- Cameras -->


### PR DESCRIPTION
When Joseph Handsome made changes to localization, it created issues for simulation localization. Specifically Joe made a parent of base_link and localization would be based off this. But in the simulation urdf this link did not exist. So I added the link the same way Joe added it in the real life sub urdf file. But then gazebo screamed at me for not giving the link physical attributes so I added that aswell.