### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,26 +91,12 @@ jobs:
     runs-on:
       group: mala-lab-noble
     steps:
-      - name: Configure catkin workspace folder structure
-        run: |
-          mkdir -p "$GITHUB_WORKSPACE"/catkin_ws/src
-          sudo apt reinstall python3-pip
       - name: Check out code from GitHub
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Setup ROS2 Jazzy
-        uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
-      - name: Install pip dependencies
-        run: |
-          python3 -m pip config set global.break-system-packages true
-          pip3 install -r requirements.txt
       - name: Install system dependencies and build
         run: |
-          # Needed for /etc/update-manager/release-upgrades
-          sudo apt-get install -y ubuntu-release-upgrader-core
           rm -rf build install log
           export HOME=$GITHUB_WORKSPACE/.. # Temporary fix for setup scripts
           ALLOW_NONSTANDARD_DIR=1 ./scripts/install.sh

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,7 +146,7 @@ $(hash_header)$(color "$Res")
 EOF
 
 # Ensure that locales are set up correctly
-sudo apt update && sudo apt install locales
+sudo apt update && sudo apt install -y locales
 sudo locale-gen en_US en_US.UTF-8
 sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 export LANG=en_US.UTF-8


### PR DESCRIPTION
Our CI runs some `apt` commands before `apt update`, causing breakage when the package repos in our CI runners become too old (and point to deleted packages). This removes the unneeded commands (our install script runs `apt update` anyways).