### PR TITLE
Run `rosdep install` in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -239,6 +239,7 @@ sudo apt-get install -y python3-rosdep
 sudo rm -rf /etc/ros/rosdep/sources.list.d/* # Delete this file first - if not deleted, error could be thrown
 sudo rosdep init
 sudo rosdep update
+sudo rosdep install --from-paths src --ignore-src -r -y
 
 # If this script is not ~/mil2/scripts/install.sh, throw an error to prevent members
 # from installing the repo in the wrong location. Setting ALLOW_NONSTANDARD_DIR=1

--- a/src/subjugator/subjugator_bringup/package.xml
+++ b/src/subjugator/subjugator_bringup/package.xml
@@ -8,7 +8,6 @@
   <license>Apache 2.0</license>
   <author>Keith Khadar</author>
 
-  <depend>joint_state_publisher_gui</depend>
   <depend>ros_gz</depend>
   <depend>sdformat_urdf</depend>
   <depend>subjugator_description</depend>


### PR DESCRIPTION
Run `rosdep install` in `install.sh` for #318 (needs `behaviortree_cpp`).
An alternative is install `behaviortree` manually in `install.sh`.

Also removes unused dependency `joint_state_publisher_gui`.
Another is `time` in the `vision_stack` submodule.