### PR TITLE
Custom spike status ROS Message

### DIFF
--- a/src/subjugator/subjugator_msgs/msg/SensorSpike.msg
+++ b/src/subjugator/subjugator_msgs/msg/SensorSpike.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+bool spike_detected
+string sensor_type  # "imu_x", "imu_y", "imu_z", etc.
+float64 measured_value

--- a/src/subjugator/subjugator_msgs/msg/SensorSpikeArray.msg
+++ b/src/subjugator/subjugator_msgs/msg/SensorSpikeArray.msg
@@ -1,0 +1,5 @@
+#list of sensor spikes, will be published on /sensors_status
+
+std_msgs/Header header
+
+SensorSpike[] sensorsStatus


### PR DESCRIPTION
Added new custom ROS messages for detecting sensor spikes. This will be integrated into the sensor_monitoring and the messages will be published when a spike is detected. 