### PR TITLE
reorder the args of git diff to make it work

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,8 +117,8 @@ jobs:
           done < <(
             git diff --name-only origin/main \
               --ignore-submodules \
-              -- "*.cpp" "*.h" "*.hpp" \
-              --diff-filter=ACMRT
+              --diff-filter=ACMRT \
+              -- "*.cpp" "*.h" "*.hpp"
           )
           cd "$GITHUB_WORKSPACE"
           tidy "${ALL_CHANGES[@]}"


### PR DESCRIPTION
The old fix has wrong argument order which will make the filter useless. This new one correct the issue.