### PR TITLE
`scripts/install.sh`: Fix `apt-add-repository` being called before installing `software-properties-common`

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,15 +84,15 @@ Fetching latest apt packages...
 $(hash_header)
 EOF
 
+# Installation for virtual machines$
+# Installs the apt-add-repository command
+sudo apt-get install software-properties-common -y
+
 # Install neovim (to prevent cameron from going mad)
 sudo apt-add-repository ppa:neovim-ppa/stable -y
 
 # Update apt
 sudo apt update
-
-# Installation for virtual machines
-# Installs the apt-add-repository command
-sudo apt-get install software-properties-common -y
 
 # Installs keyboard config without prompting for input
 sudo DEBIAN_FRONTEND=noninteractive apt-get install keyboard-configuration -y # Weird bug


### PR DESCRIPTION
This fixes an issue in `scripts/install.sh` where `apt-add-repository` is being called before `software-properties-common` is installed, breaking the script on machines which don't already have `apt-add-repository`:

https://github.com/uf-mil/mil2/blob/3c10b52fe5a3e74ae04f6331e2e542f9dbce0d71/scripts/install.sh?plain=1#L87-L95