### PR TITLE
Add per-vehicle metapackages and cb command

### DIFF
--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -92,7 +92,10 @@ cb() {
 	done
 
 	if [ "${#packages[@]}" -eq 0 ]; then
-		rm_symlink_dirs                                     # remove symlink directories
+		rm_symlink_dirs # remove symlink directories
+		if [ -n "$CB_META" ]; then
+			colcon_flags+=("--packages-up-to" "$CB_META")
+		fi
 		colcon build --symlink-install "${colcon_flags[@]}" # Build the workspace
 	else
 		colcon build --symlink-install "${colcon_flags[@]}" --packages-select "${packages[@]}" # Build the workspace

--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -90,7 +90,10 @@ cb() {
 	done
 
 	if [ "${#packages[@]}" -eq 0 ]; then
-		rm_symlink_dirs                                     # remove symlink directories
+		rm_symlink_dirs # remove symlink directories
+		if [ -n "$CB_META" ]; then
+			colcon_flags+=("--packages-up-to" "$CB_META")
+		fi
 		colcon build --symlink-install "${colcon_flags[@]}" # Build the workspace
 	else
 		colcon build --symlink-install "${colcon_flags[@]}" --packages-select "${packages[@]}" # Build the workspace

--- a/src/prop/meta/CMakeLists.txt
+++ b/src/prop/meta/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.8)
+project(prop)
+
+find_package(ament_cmake REQUIRED)
+ament_package()

--- a/src/prop/meta/package.xml
+++ b/src/prop/meta/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>prop</name>
+  <version>0.0.0</version>
+  <description>PropaGator metapackage</description>
+  <license>TODO</license>
+  <maintainer email="a@a.com">Dean</maintainer>
+
+  <depend>prop_gazebo</depend>
+  <depend>pcd</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/prop/meta/package.xml
+++ b/src/prop/meta/package.xml
@@ -7,8 +7,8 @@
   <license>TODO</license>
   <maintainer email="a@a.com">Dean</maintainer>
 
-  <depend>prop_gazebo</depend>
   <depend>pcd</depend>
+  <depend>prop_gazebo</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/subjugator/meta/CMakeLists.txt
+++ b/src/subjugator/meta/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.8)
+project(subjugator)
+
+find_package(ament_cmake REQUIRED)
+ament_package()

--- a/src/subjugator/meta/package.xml
+++ b/src/subjugator/meta/package.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>subjugator</name>
+  <version>0.0.0</version>
+  <description>SubjuGator metapackage</description>
+  <license>TODO</license>
+  <maintainer email="a@a.com">Dean</maintainer>
+
+  <depend>depth_driver</depend>
+  <depend>down_cam</depend>
+  <depend>electrical_protocol</depend>
+  <depend>front_cam</depend>
+  <depend>libwaterlinked</depend>
+  <depend>mil_msgs</depend>
+  <depend>mil_passive_sonar</depend>
+  <depend>mission_planner</depend>
+  <depend>nav_channel</depend>
+  <depend>new_depth_driver</depend>
+  <depend>servo_controller</depend>
+  <depend>subjugator_bringup</depend>
+  <depend>subjugator_centroids</depend>
+  <depend>subjugator_controller</depend>
+  <depend>subjugator_description</depend>
+  <depend>subjugator_gazebo</depend>
+  <depend>subjugator_joy</depend>
+  <depend>subjugator_keyboard_control</depend>
+  <depend>subjugator_localization</depend>
+  <depend>subjugator_mission_planner</depend>
+  <depend>subjugator_msgs</depend>
+  <depend>subjugator_path_planner</depend>
+  <depend>subjugator_sensor_monitoring</depend>
+  <depend>subjugator_thruster_manager</depend>
+  <depend>subjugator_trajectory_planner</depend>
+  <depend>subjugator_vision</depend>
+  <depend>subjugator_wrench_tuner</depend>
+  <depend>thrust_and_kill_board</depend>
+  <depend>vectornav</depend>
+  <depend>vectornav_msgs</depend>
+  <depend>waterlinked_dvl_driver</depend>
+  <depend>yolo_bringup</depend>
+  <depend>yolo_msgs</depend>
+  <depend>yolo_ros</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/subjugator/meta/package.xml
+++ b/src/subjugator/meta/package.xml
@@ -7,39 +7,26 @@
   <license>TODO</license>
   <maintainer email="a@a.com">Dean</maintainer>
 
-  <depend>depth_driver</depend>
   <depend>down_cam</depend>
-  <depend>electrical_protocol</depend>
   <depend>front_cam</depend>
-  <depend>libwaterlinked</depend>
   <depend>mil_msgs</depend>
   <depend>mil_passive_sonar</depend>
   <depend>mission_planner</depend>
-  <depend>nav_channel</depend>
   <depend>new_depth_driver</depend>
   <depend>servo_controller</depend>
   <depend>subjugator_bringup</depend>
-  <depend>subjugator_centroids</depend>
   <depend>subjugator_controller</depend>
   <depend>subjugator_description</depend>
   <depend>subjugator_gazebo</depend>
-  <depend>subjugator_joy</depend>
   <depend>subjugator_keyboard_control</depend>
   <depend>subjugator_localization</depend>
   <depend>subjugator_mission_planner</depend>
   <depend>subjugator_msgs</depend>
   <depend>subjugator_path_planner</depend>
-  <depend>subjugator_sensor_monitoring</depend>
   <depend>subjugator_thruster_manager</depend>
   <depend>subjugator_trajectory_planner</depend>
-  <depend>subjugator_vision</depend>
-  <depend>subjugator_wrench_tuner</depend>
   <depend>thrust_and_kill_board</depend>
-  <depend>vectornav</depend>
-  <depend>vectornav_msgs</depend>
   <depend>waterlinked_dvl_driver</depend>
-  <depend>yolo_bringup</depend>
-  <depend>yolo_msgs</depend>
   <depend>yolo_ros</depend>
 
   <export>


### PR DESCRIPTION
Set `CB_META=subjugator` to build only SubjuGator packages when running `cb`.