### PR TITLE
Skip CUDA packages on GPU-less machines & Fix typing-extensions pip conflict

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -210,6 +210,14 @@ $(hash_header)$(color "$Res")
 EOF
 
 # Install Python 3 dependencies
+if command -v nvidia-smi; then
+	echo "NVIDIA GPU detected; torch will be installed with CUDA support."
+else
+	echo "No NVIDIA GPU detected; pre-installing CPU-only torch (saves ~4 GB)."
+	sudo pip3 install --index-url https://download.pytorch.org/whl/cpu \
+		torch torchvision
+fi
+
 sudo pip3 install --ignore-installed typing_extensions # preinstalled
 sudo pip3 install -r requirements.txt
 


### PR DESCRIPTION
Two fixes for the `scripts/install.sh` script for python dependencies:

1. Install CPU-only torch on machines without an NVIDIA GPU. `requirements.txt` pulls torch which includes ~4GB of CUDA packages. The script now detects and NVIDIA GPU via PCI vendor ID `0x10de`. If no ID is found it reinstalls `torch` / `torchvision` from the CPU wheel index and purges orphaned CUDA wheels.

2. Pre-install `typing-extensions` to avoid a pip uninstall failure. apt ships `python3-typing-extensions` without a pip `RECORD` file, so pip cannot uninstall it when a transitive dep needs a newer version. Installing it once with `--ignore-installed` sidesteps the conflict.

This PR saves ~4GB of download + disk on most laptops (non-NVIDIA GPU) with no runtime impact. It also fixes a pip install failure due to `typing extensions`.

Testing:

Ran the full `install.sh` on Ubuntu noble (no NVIDIA GPU)

- All 54 packages built; "Installation complete"
- `torch` resolves to `2.12.0+cpu`, `torch.cuda.is_available() == False`.
- No `nvidia-*` / `cuda-*` / `triton` wheels left installed.
- Green CI

Has not been tested on a machine with an NVIDIA GPU. Maybe someone with one can test on their machine?