### PR TITLE
Add ROS2 auto-complete support for run and launch commands

### DIFF
--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -354,30 +354,27 @@ _mp_complete() {
 complete -F _mp_complete mp
 
 # Fast cached tab completion for ros2 run / ros2 launch
-if [ -n "$ZSH_VERSION" ]; then
-	_ros2_autocomplete() {
-		# shellcheck disable=SC2154,SC1087,SC2125
-		local prev=$words[CURRENT-1]
-		local pkg_cache=/tmp/.ros2_autocomplete_pkgs
+_ros2_autocomplete() {
+	local prev="${COMP_WORDS[COMP_CWORD - 1]}"
+	local pkg_cache=/tmp/.ros2_autocomplete_pkgs
 
-		[[ $prev == run || $prev == launch ]] || return
+	[[ $prev == run || $prev == launch ]] || return
 
-		# Synchronous fallback if cache doesn't exist
-		[ ! -f "$pkg_cache" ] && ros2 pkg list >"$pkg_cache" 2>/dev/null
+	# Synchronous fallback if cache doesn't exist
+	[ ! -f "$pkg_cache" ] && ros2 pkg list >"$pkg_cache" 2>/dev/null
 
-		# Fetch the list of packages from cache
-		local -a pkgs=()
-		while IFS='' read -r line; do pkgs+=("$line"); done <"$pkg_cache"
-		compadd -- "${pkgs[@]}"
+	COMPREPLY=()
+	while IFS='' read -r line; do
+		COMPREPLY+=("$line")
+	done < <(compgen -W "$(cat "$pkg_cache")" -- "${COMP_WORDS[COMP_CWORD]}")
 
-		# Update cache in background (if nobody else is doing it)
-		(flock -n "$pkg_cache.new" bash -c \
-			"source '$MIL_REPO/install/setup.bash' 2>/dev/null && \
-			 ros2 pkg list >$pkg_cache.new 2>/dev/null && \
-			 cp $pkg_cache.new $pkg_cache" &)
-	}
-	compdef _ros2_autocomplete ros2
-fi
+	# Update cache in background (if nobody else is doing it)
+	(flock -n "$pkg_cache.new" bash -c \
+		"source '$MIL_REPO/install/setup.bash' 2>/dev/null && \
+		 ros2 pkg list >$pkg_cache.new 2>/dev/null && \
+		 cp $pkg_cache.new $pkg_cache" &)
+}
+complete -F _ros2_autocomplete ros2
 
 # Swap yolo model
 yolo-swap() {

--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -356,16 +356,19 @@ complete -F _mp_complete mp
 # Fast cached tab completion for ros2 run / ros2 launch
 if [ -n "$ZSH_VERSION" ]; then
 	_ros2_autocomplete() {
+		# shellcheck disable=SC2154,SC1087,SC2125
 		local prev=$words[CURRENT-1]
 		local pkg_cache=/tmp/.ros2_autocomplete_pkgs
 
-		[[ $prev = run || $prev = launch ]] || return
+		[[ $prev == run || $prev == launch ]] || return
 
 		# Synchronous fallback if cache doesn't exist
 		[ ! -f "$pkg_cache" ] && ros2 pkg list >"$pkg_cache" 2>/dev/null
 
 		# Fetch the list of packages from cache
-		compadd -- ${(f)"$(cat $pkg_cache)"}
+		local -a pkgs=()
+		while IFS='' read -r line; do pkgs+=("$line"); done <"$pkg_cache"
+		compadd -- "${pkgs[@]}"
 
 		# Update cache in background (if nobody else is doing it)
 		(flock -n "$pkg_cache.new" bash -c \

--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -353,6 +353,29 @@ _mp_complete() {
 }
 complete -F _mp_complete mp
 
+# Fast cached tab completion for ros2 run / ros2 launch
+if [ -n "$ZSH_VERSION" ]; then
+	_ros2_autocomplete() {
+		local prev=$words[CURRENT-1]
+		local pkg_cache=/tmp/.ros2_autocomplete_pkgs
+
+		[[ $prev = run || $prev = launch ]] || return
+
+		# Synchronous fallback if cache doesn't exist
+		[ ! -f "$pkg_cache" ] && ros2 pkg list >"$pkg_cache" 2>/dev/null
+
+		# Fetch the list of packages from cache
+		compadd -- ${(f)"$(cat $pkg_cache)"}
+
+		# Update cache in background (if nobody else is doing it)
+		(flock -n "$pkg_cache.new" bash -c \
+			"source '$MIL_REPO/install/setup.bash' 2>/dev/null && \
+			 ros2 pkg list >$pkg_cache.new 2>/dev/null && \
+			 cp $pkg_cache.new $pkg_cache" &)
+	}
+	compdef _ros2_autocomplete ros2
+fi
+
 # Swap yolo model
 yolo-swap() {
 	if [[ -z $1 ]]; then


### PR DESCRIPTION
### First Tab press (cold cache):

zsh triggers `_ros2_autocomplete`
prev = "run" → passes the guard
`/tmp/.ros2_autocomplete_pkgs`doesn't exist → runs ros2 pkg list synchronously and saves to cache
Reads cache, feeds all package names to zsh via COMPREPLY and compgen
Spawns a background job to refresh the cache for next time

### Subsequent Tab presses (warm cache):

Same function fires
Cache file exists → skips the slow `ros2 pkg list` call
Reads cache instantly, feeds package names via COMPREPLY and compgen
Background refresh runs (blocked by flock -n if one is already running — prevents duplicate refreshes)

### The background refresh:

`flock -n` tries to acquire a lock on a temp file — if another refresh is already running, it exits immediately (the -n means non-blocking)
Runs `ros2 pkg` list in a subshell that explicitly sources the workspace (source install/setup.bash) so it sees your custom packages, not just system ROS2 packages
Atomically swaps the new cache in once done