### PR TITLE
fix zenoh install script

### DIFF
--- a/hw/zenoh.service
+++ b/hw/zenoh.service
@@ -2,7 +2,7 @@
 
 [Service]
 ExecStart=sh -c '. /opt/ros/jazzy/setup.sh; ros2 run rmw_zenoh_cpp rmw_zenohd'
-Environment=ZENOH_ROUTER_CONFIG_URI=/home/sub9/mil2/zenoh_config.json5
+Environment=ZENOH_ROUTER_CONFIG_URI=MIL_HOME/mil2/zenoh_config.json5
 Environment=ROS_DOMAIN_ID=37
 
 [Install]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -236,8 +236,9 @@ if [[ $SCRIPT_DIR != "$HOME/mil2/scripts" && -z ${ALLOW_NONSTANDARD_DIR:-} ]]; t
 fi
 
 install_zenoh() {
-	sudo cp "$SCRIPT_DIR/../hw/zenoh.service" /etc/systemd/system
-	systemctl enable zenoh --now || true
+	sed "s|MIL_HOME|$HOME|" "$SCRIPT_DIR/../hw/zenoh.service" |
+		sudo tee /etc/systemd/system/zenoh.service
+	sudo systemctl enable zenoh --now || true
 }
 install_zenoh
 


### PR DESCRIPTION
Somebody should test on their system to make this works. We also want a shortcut to start it without systemd (mainly for users in containers), maybe a `/etc/init.d` script?