### PR TITLE
Add pose trajectory script for manual PID tuning

### DIFF
--- a/src/subjugator/mission_planner/CMakeLists.txt
+++ b/src/subjugator/mission_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(mission_planner)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -61,6 +61,23 @@ ament_target_dependencies(
   lifecycle_msgs
   rcl_interfaces
   ament_index_cpp)
+
+target_precompile_headers(
+  operations
+  PRIVATE
+  <behaviortree_cpp/bt_factory.h>
+  <behaviortree_cpp/action_node.h>
+  <behaviortree_cpp/basic_types.h>
+  <rclcpp/rclcpp.hpp>
+  <yolo_msgs/msg/detection_array.hpp>
+  <geometry_msgs/msg/pose.hpp>
+  <memory>
+  <string>
+  <vector>
+  <optional>
+  <algorithm>
+  <cmath>
+  <chrono>)
 
 # Node
 add_executable(mission_planner_node src/mission_planner_node.cpp)

--- a/src/subjugator/mission_planner/CMakeLists.txt
+++ b/src/subjugator/mission_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.14)
 project(mission_planner)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -61,23 +61,6 @@ ament_target_dependencies(
   lifecycle_msgs
   rcl_interfaces
   ament_index_cpp)
-
-target_precompile_headers(
-  operations
-  PRIVATE
-  <behaviortree_cpp/bt_factory.h>
-  <behaviortree_cpp/action_node.h>
-  <behaviortree_cpp/basic_types.h>
-  <rclcpp/rclcpp.hpp>
-  <yolo_msgs/msg/detection_array.hpp>
-  <geometry_msgs/msg/pose.hpp>
-  <memory>
-  <string>
-  <vector>
-  <optional>
-  <algorithm>
-  <cmath>
-  <chrono>)
 
 # Node
 add_executable(mission_planner_node src/mission_planner_node.cpp)

--- a/src/subjugator/scripts/mock_odom.py
+++ b/src/subjugator/scripts/mock_odom.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+"""
+Simulate sub odometry for testing move_poses.py on a laptop.
+
+Listens to /goal/trajectory and gradually "moves" a simulated position
+toward the goal, publishing the result to /odometry/filtered.
+
+Usage:
+  python3 mock_odom.py              # default speed 0.3 m/s
+  python3 mock_odom.py --speed 0.5  # faster simulation
+  python3 mock_odom.py --start 0,0,-1,0  # custom start pose
+"""
+
+import argparse
+import math
+
+import rclpy
+from geometry_msgs.msg import Pose, PoseWithCovariance, PoseWithCovarianceStamped, Quaternion
+from nav_msgs.msg import Odometry
+from rclpy.node import Node
+
+
+class MockOdom(Node):
+    def __init__(self, start_pose: Pose, speed: float):
+        super().__init__("mock_odom")
+        self.current = start_pose
+        self.goal: Pose | None = None
+        self.speed = speed  # m/s
+
+        self.odom_pub = self.create_publisher(Odometry, "/odometry/filtered", 10)
+        self.goal_sub = self.create_subscription(
+            Pose, "/goal/trajectory", self._goal_cb, 1
+        )
+
+        # update at 20 Hz
+        self.create_timer(0.05, self._update)
+        self.get_logger().info(f"Mock odom started  speed={speed}m/s")
+
+    def _goal_cb(self, msg: Pose) -> None:
+        self.goal = msg
+        p = msg.position
+        self.get_logger().info(f"New goal → x={p.x:.2f}  y={p.y:.2f}  z={p.z:.2f}")
+
+    def _update(self) -> None:
+        if self.goal is not None:
+            self._step_toward_goal()
+        self._publish()
+
+    def _step_toward_goal(self) -> None:
+        dx = self.goal.position.x - self.current.position.x
+        dy = self.goal.position.y - self.current.position.y
+        dz = self.goal.position.z - self.current.position.z
+        dist = math.sqrt(dx * dx + dy * dy + dz * dz)
+
+        if dist < 0.01:
+            return
+
+        # move one timestep toward goal (dt=0.05s)
+        step = min(self.speed * 0.05, dist)
+        scale = step / dist
+        self.current.position.x += dx * scale
+        self.current.position.y += dy * scale
+        self.current.position.z += dz * scale
+
+    def _publish(self) -> None:
+        msg = Odometry()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = "odom"
+        msg.child_frame_id = "base_link"
+        msg.pose.pose = self.current
+        self.odom_pub.publish(msg)
+
+
+def _parse_start(s: str) -> Pose:
+    parts = s.split(",")
+    if len(parts) != 4:
+        raise argparse.ArgumentTypeError(f"Expected x,y,z,yaw_deg — got: {s!r}")
+    x, y, z, yaw_deg = map(float, parts)
+    p = Pose()
+    p.position.x = x
+    p.position.y = y
+    p.position.z = z
+    yaw_rad = math.radians(yaw_deg)
+    p.orientation.w = math.cos(yaw_rad / 2.0)
+    p.orientation.z = math.sin(yaw_rad / 2.0)
+    return p
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate sub odometry for testing move_poses.py")
+    parser.add_argument("--speed", type=float, default=0.3, help="Simulated movement speed in m/s (default: 0.3)")
+    parser.add_argument("--start", default="0,0,-1,0", metavar="x,y,z,yaw_deg", help="Starting pose (default: 0,0,-1,0)")
+
+    args, _ = parser.parse_known_args()
+    start_pose = _parse_start(args.start)
+
+    rclpy.init()
+    node = MockOdom(start_pose, args.speed)
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/subjugator/scripts/mock_odom.py
+++ b/src/subjugator/scripts/mock_odom.py
@@ -16,7 +16,9 @@ import argparse
 import math
 
 import rclpy
-from geometry_msgs.msg import Pose, PoseWithCovariance, PoseWithCovarianceStamped, Quaternion
+from geometry_msgs.msg import (
+    Pose,
+)
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
 
@@ -30,7 +32,10 @@ class MockOdom(Node):
 
         self.odom_pub = self.create_publisher(Odometry, "/odometry/filtered", 10)
         self.goal_sub = self.create_subscription(
-            Pose, "/goal/trajectory", self._goal_cb, 1
+            Pose,
+            "/goal/trajectory",
+            self._goal_cb,
+            1,
         )
 
         # update at 20 Hz
@@ -88,9 +93,21 @@ def _parse_start(s: str) -> Pose:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Simulate sub odometry for testing move_poses.py")
-    parser.add_argument("--speed", type=float, default=0.3, help="Simulated movement speed in m/s (default: 0.3)")
-    parser.add_argument("--start", default="0,0,-1,0", metavar="x,y,z,yaw_deg", help="Starting pose (default: 0,0,-1,0)")
+    parser = argparse.ArgumentParser(
+        description="Simulate sub odometry for testing move_poses.py",
+    )
+    parser.add_argument(
+        "--speed",
+        type=float,
+        default=0.3,
+        help="Simulated movement speed in m/s (default: 0.3)",
+    )
+    parser.add_argument(
+        "--start",
+        default="0,0,-1,0",
+        metavar="x,y,z,yaw_deg",
+        help="Starting pose (default: 0,0,-1,0)",
+    )
 
     args, _ = parser.parse_known_args()
     start_pose = _parse_start(args.start)

--- a/src/subjugator/scripts/move_poses.py
+++ b/src/subjugator/scripts/move_poses.py
@@ -64,7 +64,10 @@ class MovePoses(Node):
 
         self.goal_pub = self.create_publisher(Pose, "/goal/trajectory", 1)
         self.odom_sub = self.create_subscription(
-            Odometry, "/odometry/filtered", self._odom_cb, 10
+            Odometry,
+            "/odometry/filtered",
+            self._odom_cb,
+            10,
         )
 
     def _odom_cb(self, msg: Odometry) -> None:
@@ -77,12 +80,14 @@ class MovePoses(Node):
 
         print(
             f"Moving through {len(self.poses)} pose(s) "
-            f"[tolerance={self.tolerance}m  timeout={self.timeout}s]"
+            f"[tolerance={self.tolerance}m  timeout={self.timeout}s]",
         )
 
         for i, pose in enumerate(self.poses):
             p = pose.position
-            print(f"\n[{i + 1}/{len(self.poses)}] Goal → x={p.x:.2f}  y={p.y:.2f}  z={p.z:.2f}")
+            print(
+                f"\n[{i + 1}/{len(self.poses)}] Goal → x={p.x:.2f}  y={p.y:.2f}  z={p.z:.2f}",
+            )
             self.goal_pub.publish(pose)
 
             start = time.monotonic()
@@ -96,7 +101,9 @@ class MovePoses(Node):
                     break
 
                 if elapsed > self.timeout:
-                    print(f"  Timeout after {elapsed:.1f}s  (dist={dist:.3f}m) — advancing anyway")
+                    print(
+                        f"  Timeout after {elapsed:.1f}s  (dist={dist:.3f}m) — advancing anyway",
+                    )
                     break
 
         print("\nDone.")
@@ -120,7 +127,10 @@ def _load_yaml(path: str) -> list[Pose]:
         data = yaml.safe_load(f)
     return [
         _make_pose(
-            float(e["x"]), float(e["y"]), float(e["z"]), float(e.get("yaw_deg", 0.0))
+            float(e["x"]),
+            float(e["y"]),
+            float(e["z"]),
+            float(e.get("yaw_deg", 0.0)),
         )
         for e in data["poses"]
     ]
@@ -132,12 +142,20 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Example: python3 move_poses.py --poses 0,0,-1,0  2,0,-1,90",
     )
-    parser.add_argument(
-        "--poses", nargs="+", type=_parse_pose, metavar="x,y,z,yaw_deg"
-    )
+    parser.add_argument("--poses", nargs="+", type=_parse_pose, metavar="x,y,z,yaw_deg")
     parser.add_argument("--file", metavar="PATH", help="YAML file with pose list")
-    parser.add_argument("--tolerance", type=float, default=0.3, help="Goal tolerance in meters (default: 0.3)")
-    parser.add_argument("--timeout", type=float, default=60.0, help="Per-pose timeout in seconds (default: 60)")
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=0.3,
+        help="Goal tolerance in meters (default: 0.3)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Per-pose timeout in seconds (default: 60)",
+    )
 
     args, _ = parser.parse_known_args()
 

--- a/src/subjugator/scripts/move_poses.py
+++ b/src/subjugator/scripts/move_poses.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+"""
+Move the sub through a sequence of poses via /goal/trajectory.
+
+Publishes each pose directly to the PID controller and waits until
+the sub reaches it (within tolerance) before advancing to the next.
+
+Usage:
+  python3 move_poses.py --poses 0,0,-1,0  2,0,-1,0  2,2,-1,90
+  python3 move_poses.py --file poses.yaml
+  python3 move_poses.py --tolerance 0.3 --timeout 30 --poses 0,0,-1,0
+
+Pose format: x,y,z,yaw_deg
+
+YAML file format:
+  poses:
+    - {x: 0.0, y: 0.0, z: -1.0, yaw_deg: 0.0}
+    - {x: 2.0, y: 0.0, z: -1.0, yaw_deg: 90.0}
+"""
+
+import argparse
+import math
+import time
+
+import rclpy
+from geometry_msgs.msg import Pose, Quaternion
+from nav_msgs.msg import Odometry
+from rclpy.node import Node
+
+
+def _yaw_to_quat(yaw_rad: float) -> Quaternion:
+    q = Quaternion()
+    q.w = math.cos(yaw_rad / 2.0)
+    q.x = 0.0
+    q.y = 0.0
+    q.z = math.sin(yaw_rad / 2.0)
+    return q
+
+
+def _make_pose(x: float, y: float, z: float, yaw_deg: float) -> Pose:
+    p = Pose()
+    p.position.x = x
+    p.position.y = y
+    p.position.z = z
+    p.orientation = _yaw_to_quat(math.radians(yaw_deg))
+    return p
+
+
+def _distance(a: Pose, b: Pose) -> float:
+    dx = a.position.x - b.position.x
+    dy = a.position.y - b.position.y
+    dz = a.position.z - b.position.z
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+
+
+class MovePoses(Node):
+    def __init__(self, poses: list[Pose], tolerance: float, timeout: float):
+        super().__init__("move_poses")
+        self.poses = poses
+        self.tolerance = tolerance
+        self.timeout = timeout
+        self.current_pose: Pose | None = None
+
+        self.goal_pub = self.create_publisher(Pose, "/goal/trajectory", 1)
+        self.odom_sub = self.create_subscription(
+            Odometry, "/odometry/filtered", self._odom_cb, 10
+        )
+
+    def _odom_cb(self, msg: Odometry) -> None:
+        self.current_pose = msg.pose.pose
+
+    def run(self) -> None:
+        print("Waiting for odometry...")
+        while rclpy.ok() and self.current_pose is None:
+            rclpy.spin_once(self, timeout_sec=0.1)
+
+        print(
+            f"Moving through {len(self.poses)} pose(s) "
+            f"[tolerance={self.tolerance}m  timeout={self.timeout}s]"
+        )
+
+        for i, pose in enumerate(self.poses):
+            p = pose.position
+            print(f"\n[{i + 1}/{len(self.poses)}] Goal → x={p.x:.2f}  y={p.y:.2f}  z={p.z:.2f}")
+            self.goal_pub.publish(pose)
+
+            start = time.monotonic()
+            while rclpy.ok():
+                rclpy.spin_once(self, timeout_sec=0.05)
+                dist = _distance(self.current_pose, pose)
+                elapsed = time.monotonic() - start
+
+                if dist < self.tolerance:
+                    print(f"  Reached in {elapsed:.1f}s  (dist={dist:.3f}m)")
+                    break
+
+                if elapsed > self.timeout:
+                    print(f"  Timeout after {elapsed:.1f}s  (dist={dist:.3f}m) — advancing anyway")
+                    break
+
+        print("\nDone.")
+
+
+def _parse_pose(s: str) -> Pose:
+    parts = s.split(",")
+    if len(parts) != 4:
+        raise argparse.ArgumentTypeError(f"Expected x,y,z,yaw_deg — got: {s!r}")
+    try:
+        x, y, z, yaw_deg = map(float, parts)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(str(e))
+    return _make_pose(x, y, z, yaw_deg)
+
+
+def _load_yaml(path: str) -> list[Pose]:
+    import yaml
+
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return [
+        _make_pose(
+            float(e["x"]), float(e["y"]), float(e["z"]), float(e.get("yaw_deg", 0.0))
+        )
+        for e in data["poses"]
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Move sub through a sequence of poses via /goal/trajectory",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Example: python3 move_poses.py --poses 0,0,-1,0  2,0,-1,90",
+    )
+    parser.add_argument(
+        "--poses", nargs="+", type=_parse_pose, metavar="x,y,z,yaw_deg"
+    )
+    parser.add_argument("--file", metavar="PATH", help="YAML file with pose list")
+    parser.add_argument("--tolerance", type=float, default=0.3, help="Goal tolerance in meters (default: 0.3)")
+    parser.add_argument("--timeout", type=float, default=60.0, help="Per-pose timeout in seconds (default: 60)")
+
+    args, _ = parser.parse_known_args()
+
+    if args.poses:
+        poses = args.poses
+    elif args.file:
+        poses = _load_yaml(args.file)
+    else:
+        parser.error("Provide --poses or --file")
+
+    rclpy.init()
+    node = MovePoses(poses, args.tolerance, args.timeout)
+    try:
+        node.run()
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Add two scripts to support manual PID tuning without needing to run
the full mission planner:

- move_poses.py: moves the sub through a sequence of poses by publishing
  directly to /goal/trajectory, waiting for each pose to be reached
  (within tolerance) before advancing to the next. Accepts poses as CLI
  arguments (x,y,z,yaw_deg) or a YAML file.

- mock_odom.py: simulates sub odometry for testing move_poses.py on a
  laptop without hardware. Listens to /goal/trajectory and publishes a
  fake /odometry/filtered that gradually moves toward the goal.
  Included as a testing utility for when hardware is unavailable.

- the reason I pushed mock_odom is that it allows anyone to validate pose trajectory logic on a laptop at any time.

# Testing using mock_odom.py

### terminal 1
python3 src/subjugator/scripts/mock_odom.py --start 0,0,-1,0

### terminal 2
python3 src/subjugator/scripts/move_poses.py --poses 0,0,-1,0  2,0,-1,0  2,2,-1,90

Run 1 (fresh start):
```
[1/3] Goal → x=0.00  y=0.00  z=-1.00   Reached in 0.0s  (dist=0.000m)
[2/3] Goal → x=2.00  y=0.00  z=-1.00   Reached in 5.7s  (dist=0.290m)
[3/3] Goal → x=2.00  y=2.00  z=-1.00   Reached in 5.7s  (dist=0.296m)
```

Run 2 (mock_odom not restarted, started from previous position):
```
[1/3] Goal → x=0.00  y=0.00  z=-1.00   Reached in 8.4s  (dist=0.293m)
[2/3] Goal → x=2.00  y=0.00  z=-1.00   Reached in 5.0s  (dist=0.289m)
[3/3] Goal → x=2.00  y=5.00  z=-1.00   Reached in 15.6s (dist=0.295m)
```

All poses reached within tolerance (0.3m), no timeouts.
Note: remember to restart mock_odom.py between runs, otherwise it
continues from the last position.
#505 