### PR TITLE
Add sim detection publisher for automated training data collection

### DIFF
--- a/src/subjugator/gnc/subjugator_vision/CMakeLists.txt
+++ b/src/subjugator/gnc/subjugator_vision/CMakeLists.txt
@@ -13,9 +13,10 @@ find_package(mil_msgs REQUIRED)
 include_directories(include)
 
 # Python scripts
-install(PROGRAMS scripts/save_down_images.py scripts/save_front_images.py
-                 scripts/swap_yolo_model.py scripts/sim_detection_publisher.py
-        DESTINATION lib/${PROJECT_NAME})
+install(
+  PROGRAMS scripts/save_down_images.py scripts/save_front_images.py
+           scripts/swap_yolo_model.py scripts/sim_detection_publisher.py
+           scripts/generate_sim_objects_yaml.py DESTINATION lib/${PROJECT_NAME})
 
 # Config files
 install(DIRECTORY config/ DESTINATION share/${PROJECT_NAME}/config)

--- a/src/subjugator/gnc/subjugator_vision/CMakeLists.txt
+++ b/src/subjugator/gnc/subjugator_vision/CMakeLists.txt
@@ -14,7 +14,11 @@ include_directories(include)
 
 # Python scripts
 install(PROGRAMS scripts/save_down_images.py scripts/save_front_images.py
-                 scripts/swap_yolo_model.py DESTINATION lib/${PROJECT_NAME})
+                 scripts/swap_yolo_model.py scripts/sim_detection_publisher.py
+        DESTINATION lib/${PROJECT_NAME})
+
+# Config files
+install(DIRECTORY config/ DESTINATION share/${PROJECT_NAME}/config)
 
 # YOLO models
 install(DIRECTORY models/ DESTINATION share/${PROJECT_NAME}/models)

--- a/src/subjugator/gnc/subjugator_vision/config/sim_objects.yaml
+++ b/src/subjugator/gnc/subjugator_vision/config/sim_objects.yaml
@@ -1,0 +1,132 @@
+---
+# Simulation object configuration for sim_detection_publisher.py
+#
+# world_name: Gazebo world name
+# camera_link: link name in Gazebo's Pose_V message to use as camera
+# gz_pose_topic: Gazebo topic publishing gz.msgs.Pose_V of dynamic poses
+#
+# Each object entry:
+#   position: [x, y, z] in world frame
+#   half_extents: [dx, dy, dz] approximate half-sizes of the 3D bounding box
+#   class_id: YOLO class index
+#   class_name: YOLO class label
+
+world_name: "robosub_2025"
+model_name: "sub9"
+camera_link: "front_cam_link"
+gz_pose_topic: "/world/robosub_2025/dynamic_pose/info"
+
+objects:
+  - name: "StartGate_A"
+    position: [-1.57, 4.28, -0.4]
+    half_extents: [0.1, 1.5, 1.0]
+    class_id: 0
+    class_name: "start_gate"
+
+  - name: "PathMarker_A1"
+    position: [-2.47, 7.0, -1.4]
+    half_extents: [0.3, 0.15, 0.03]
+    class_id: 1
+    class_name: "path_marker"
+
+  - name: "PathMarker_A2"
+    position: [6.892, 16.840, -1.4]
+    half_extents: [0.3, 0.15, 0.03]
+    class_id: 1
+    class_name: "path_marker"
+
+  - name: "RedPole1"
+    position: [6.392, 14.840, 0.0]
+    half_extents: [0.05, 0.05, 1.0]
+    class_id: 2
+    class_name: "red_pole"
+
+  - name: "RedPole2"
+    position: [3.588, 14.188, 0.0]
+    half_extents: [0.05, 0.05, 1.0]
+    class_id: 2
+    class_name: "red_pole"
+
+  - name: "RedPole3"
+    position: [1.384, 11.536, 0.0]
+    half_extents: [0.05, 0.05, 1.0]
+    class_id: 2
+    class_name: "red_pole"
+
+  - name: "LeftWhitePole"
+    position: [7.769, 12.753, 0.0]
+    half_extents: [0.05, 0.05, 1.0]
+    class_id: 3
+    class_name: "white_pole"
+
+  - name: "RightWhitePole"
+    position: [5.016, 16.927, 0.0]
+    half_extents: [0.05, 0.05, 1.0]
+    class_id: 3
+    class_name: "white_pole"
+
+  - name: "LeftWhitePole2"
+    position: [4.965, 12.101, 0.0]
+    half_extents: [0.05, 0.05, 1.0]
+    class_id: 3
+    class_name: "white_pole"
+
+  - name: "RightWhitePole2"
+    position: [2.211, 16.275, 0.0]
+    half_extents: [0.05, 0.05, 1.0]
+    class_id: 3
+    class_name: "white_pole"
+
+  - name: "LeftWhitePole3"
+    position: [2.761, 9.449, 0.0]
+    half_extents: [0.05, 0.05, 1.0]
+    class_id: 3
+    class_name: "white_pole"
+
+  - name: "RightWhitePole3"
+    position: [0.007, 13.623, 0.0]
+    half_extents: [0.05, 0.05, 1.0]
+    class_id: 3
+    class_name: "white_pole"
+
+  - name: "Bin_A"
+    position: [7.192, 20.840, -1.4]
+    half_extents: [0.3, 0.3, 0.15]
+    class_id: 4
+    class_name: "bin"
+
+  - name: "Torpedo_Board"
+    position: [-1.192, 21.840, -1.0]
+    half_extents: [0.05, 0.6, 0.6]
+    class_id: 5
+    class_name: "torpedo_board"
+
+  - name: "Octagon_2025"
+    position: [-6.25, 14.0, 0.4]
+    half_extents: [1.5, 1.5, 0.1]
+    class_id: 6
+    class_name: "octagon"
+
+  - name: "Pink_Bin"
+    position: [-6.403, 14.58, -1.0]
+    half_extents: [0.2, 0.2, 0.15]
+    class_id: 7
+    class_name: "pink_bin"
+
+  - name: "Yellow_Bin"
+    position: [-6.403, 13.45, -1.0]
+    half_extents: [0.2, 0.2, 0.15]
+    class_id: 8
+    class_name: "yellow_bin"
+
+  - name: "Yellow_Cup"
+    position: [-6.95, 14.0, -0.847]
+    half_extents: [0.06, 0.06, 0.08]
+    class_id: 9
+    class_name: "yellow_cup"
+
+  - name: "Pink_Spoon"
+    position: [-6.945, 14.076, -0.98]
+    half_extents: [0.15, 0.04, 0.02]
+    class_id: 10
+    class_name: "pink_spoon"

--- a/src/subjugator/gnc/subjugator_vision/config/sim_objects_task1_2026.yaml
+++ b/src/subjugator/gnc/subjugator_vision/config/sim_objects_task1_2026.yaml
@@ -1,0 +1,21 @@
+---
+# sim_objects config for task1_2026.world (robosub_2026 world)
+# Sub spawns at (0, 0, 0) yaw=0
+
+world_name: "robosub_2026"
+model_name: "sub9"
+camera_link: "front_cam_link"
+gz_pose_topic: "/world/robosub_2026/dynamic_pose/info"
+
+objects:
+  - name: "StartGate_A"
+    position: [7.57, 22.28, -0.4]
+    half_extents: [1.58, 0.78, 0.05]
+    class_id: 0
+    class_name: "start_gate"
+
+  - name: "StartGate_B"
+    position: [7.57, 22.28, -0.4]
+    half_extents: [1.58, 0.78, 0.05]
+    class_id: 0
+    class_name: "start_gate"

--- a/src/subjugator/gnc/subjugator_vision/config/sim_objects_task4_2026_v1.yaml
+++ b/src/subjugator/gnc/subjugator_vision/config/sim_objects_task4_2026_v1.yaml
@@ -1,0 +1,15 @@
+---
+# sim_objects config for task4_2026_v1.world
+# Sub spawns at (2, 6, -0.3) yaw=1 rad
+
+world_name: "task4_2026_v1"
+model_name: "sub9"
+camera_link: "front_cam_link"
+gz_pose_topic: "/world/task4_2026_v1/dynamic_pose/info"
+
+objects:
+  - name: "Torpedo_Board"
+    position: [-4.0, 20.0, -0.8]
+    half_extents: [0.25, 0.61, 0.35]
+    class_id: 0
+    class_name: "torpedo_board"

--- a/src/subjugator/gnc/subjugator_vision/config/sim_objects_task4_2026_v2.yaml
+++ b/src/subjugator/gnc/subjugator_vision/config/sim_objects_task4_2026_v2.yaml
@@ -1,0 +1,15 @@
+---
+# sim_objects config for task4_2026_v2.world
+# Sub spawns at (2, 6, -0.3) yaw=1 rad
+
+world_name: "task4_2026_v2"
+model_name: "sub9"
+camera_link: "front_cam_link"
+gz_pose_topic: "/world/task4_2026_v2/dynamic_pose/info"
+
+objects:
+  - name: "Torpedo_Board"
+    position: [-4.0, 20.0, -0.8]
+    half_extents: [0.25, 0.61, 0.35]
+    class_id: 0
+    class_name: "torpedo_board"

--- a/src/subjugator/gnc/subjugator_vision/package.xml
+++ b/src/subjugator/gnc/subjugator_vision/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>ultralytics</exec_depend>
   <exec_depend>vision_msgs</exec_depend>
+  <exec_depend>yolo_msgs</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/subjugator/gnc/subjugator_vision/scripts/generate_sim_objects_yaml.py
+++ b/src/subjugator/gnc/subjugator_vision/scripts/generate_sim_objects_yaml.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""
+generate_sim_objects_yaml.py
+
+Fully automatic: parses a Gazebo .world SDF file and generates a sim_objects
+yaml config for sim_detection_publisher.py.
+
+  - Object positions are read from the world file
+  - Bounding box sizes are computed from the mesh files using trimesh
+  - Class IDs and names are auto-assigned and saved to classes.yaml so the
+    same object always gets the same ID across different world files
+
+Usage:
+    python3 generate_sim_objects_yaml.py <world_file> [output.yaml]
+
+    If output path is omitted the yaml is printed to stdout.
+
+Requirements:
+    pip install trimesh pycollada
+"""
+
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import yaml
+
+# Models that are environment/infrastructure — not competition objects to detect
+SKIP_MODELS = {
+    "Water",
+    "WoollettPool",
+    "Task5_Table",
+    "North East Down frame",
+}
+SKIP_PREFIXES = ("Pinger",)
+
+
+def find_workspace_root(start_path: str) -> str | None:
+    """Walk up from start_path until we find a colcon workspace.
+    A colcon workspace has src/ alongside build/ or install/."""
+    path = os.path.abspath(start_path)
+    while path != os.path.dirname(path):
+        has_src = os.path.isdir(os.path.join(path, "src"))
+        has_build = os.path.isdir(os.path.join(path, "build")) or os.path.isdir(
+            os.path.join(path, "install"),
+        )
+        if has_src and has_build:
+            return path
+        path = os.path.dirname(path)
+    return None
+
+
+def resolve_uri(uri: str, workspace_root: str) -> str | None:
+    """
+    Resolve a Gazebo package:// URI to an absolute file path.
+    Searches the workspace src/ tree for the file by name.
+    """
+    uri = uri.strip()
+    filename = os.path.basename(uri)
+    src_root = os.path.join(workspace_root, "src")
+    for dirpath, _, filenames in os.walk(src_root):
+        if filename in filenames:
+            return os.path.join(dirpath, filename)
+    return None
+
+
+def mesh_half_extents(mesh_path: str) -> list[float] | None:
+    """Load a mesh file and return its half-extents [dx, dy, dz] in metres."""
+    try:
+        import trimesh
+
+        mesh = trimesh.load(mesh_path, force="mesh")
+        if mesh is None or not hasattr(mesh, "bounds"):
+            # Scene with multiple geometries
+            mesh = trimesh.load(mesh_path)
+            if hasattr(mesh, "geometry") and mesh.geometry:
+                all_bounds = [g.bounds for g in mesh.geometry.values()]
+                mins = np.min([b[0] for b in all_bounds], axis=0)
+                maxs = np.max([b[1] for b in all_bounds], axis=0)
+            else:
+                return None
+        else:
+            mins, maxs = mesh.bounds[0], mesh.bounds[1]
+
+        he = (maxs - mins) / 2
+        return [round(float(v), 4) for v in he]
+    except Exception as e:
+        print(f"  WARNING: trimesh failed on {mesh_path}: {e}", file=sys.stderr)
+        return None
+
+
+def model_to_class_name(model_name: str) -> str:
+    """
+    Convert a model name like 'StartGate_A', 'RedPole1', 'LeftWhitePole2'
+    to a canonical class name like 'start_gate', 'red_pole', 'white_pole'.
+
+    Strips leading Left/Right/Top/Bottom directional prefixes and trailing
+    letter/number suffixes that distinguish instances of the same object type.
+    """
+    name = model_name
+
+    # Strip trailing instance identifiers: _A, _B1, _A2, 1, 2, etc.
+    name = re.sub(r"[_\s]+[A-Z][0-9]*$", "", name)
+    name = re.sub(r"[0-9]+$", "", name)
+    name = re.sub(r"[_\s]+[A-Z][0-9]*$", "", name)  # second pass for _A1 → _A → ""
+
+    # Strip leading directional words
+    name = re.sub(r"^(Left|Right|Top|Bottom|Upper|Lower)", "", name)
+
+    # Convert CamelCase to snake_case
+    name = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", name)
+    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
+    name = name.lower().strip("_")
+
+    return name
+
+
+def load_or_create_classes(classes_path: str) -> dict[str, int]:
+    """Load existing class name → ID mapping, or return empty dict."""
+    if os.path.exists(classes_path):
+        with open(classes_path) as f:
+            data = yaml.safe_load(f) or {}
+        return {k: int(v) for k, v in data.items()}
+    return {}
+
+
+def save_classes(classes_path: str, classes: dict[str, int]) -> None:
+    with open(classes_path, "w") as f:
+        yaml.dump(dict(sorted(classes.items(), key=lambda x: x[1])), f)
+
+
+def assign_class_id(class_name: str, classes: dict[str, int]) -> int:
+    """Return existing ID for class_name, or assign the next available ID."""
+    if class_name not in classes:
+        next_id = max(classes.values(), default=-1) + 1
+        classes[class_name] = next_id
+    return classes[class_name]
+
+
+def parse_pose(pose_text: str) -> list[float]:
+    parts = pose_text.strip().split()
+    return [float(parts[0]), float(parts[1]), float(parts[2])]
+
+
+def get_model_mesh_uri(model_elem) -> str | None:
+    """Return the first package:// mesh URI found inside a model element.
+    Handles both package:// and the gz-specific package:// variant."""
+    for uri_elem in model_elem.iter("uri"):
+        text = (uri_elem.text or "").strip()
+        if re.match(r"package::?//", text) and any(
+            text.endswith(ext) for ext in (".dae", ".obj", ".stl")
+        ):
+            return text
+    return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: generate_sim_objects_yaml.py <world_file> [output.yaml]")
+        sys.exit(1)
+
+    world_path = os.path.abspath(sys.argv[1])
+    output_path = sys.argv[2] if len(sys.argv) > 2 else None
+
+    workspace_root = find_workspace_root(world_path)
+    if workspace_root is None:
+        print(
+            "ERROR: could not find workspace root (no src/ directory found above world file)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # classes.yaml lives next to this script's config directory
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    config_dir = os.path.join(script_dir, "..", "config")
+    classes_path = os.path.join(config_dir, "classes.yaml")
+    classes = load_or_create_classes(classes_path)
+
+    tree = ET.parse(world_path)
+    root = tree.getroot()
+    world_elem = root.find("world")
+    if world_elem is None:
+        print("ERROR: no <world> element found", file=sys.stderr)
+        sys.exit(1)
+
+    world_name = world_elem.get("name", "unknown")
+    objects = []
+
+    for model in world_elem.findall("model"):
+        name = model.get("name", "")
+
+        if name in SKIP_MODELS or any(name.startswith(p) for p in SKIP_PREFIXES):
+            continue
+
+        pose_elem = model.find("pose")
+        if pose_elem is None or not pose_elem.text:
+            continue
+
+        position = parse_pose(pose_elem.text)
+
+        mesh_uri = get_model_mesh_uri(model)
+        if mesh_uri is None:
+            print(f"  SKIP {name}: no mesh URI found", file=sys.stderr)
+            continue
+
+        mesh_path = resolve_uri(mesh_uri, workspace_root)
+        if mesh_path is None:
+            print(f"  SKIP {name}: could not resolve URI {mesh_uri}", file=sys.stderr)
+            continue
+
+        half_extents = mesh_half_extents(mesh_path)
+        if half_extents is None:
+            print(f"  SKIP {name}: mesh load failed", file=sys.stderr)
+            continue
+
+        class_name = model_to_class_name(name)
+        class_id = assign_class_id(class_name, classes)
+
+        print(
+            f"  {name} → class {class_id} ({class_name}), he={half_extents}",
+            file=sys.stderr,
+        )
+        objects.append((name, position, half_extents, class_id, class_name))
+
+    # Save updated classes
+    save_classes(classes_path, classes)
+
+    lines = [
+        "---",
+        f"# Auto-generated from {os.path.basename(world_path)}",
+        f"# Re-generate with: python3 generate_sim_objects_yaml.py {os.path.basename(world_path)}",
+        "",
+        f'world_name: "{world_name}"',
+        'model_name: "sub9"',
+        'camera_link: "front_cam_link"',
+        f'gz_pose_topic: "/world/{world_name}/dynamic_pose/info"',
+        "",
+        "objects:",
+    ]
+
+    for name, pos, he, class_id, class_name in objects:
+        lines += [
+            f'  - name: "{name}"',
+            f"    position: [{pos[0]}, {pos[1]}, {pos[2]}]",
+            f"    half_extents: [{he[0]}, {he[1]}, {he[2]}]",
+            f"    class_id: {class_id}",
+            f'    class_name: "{class_name}"',
+            "",
+        ]
+
+    output = "\n".join(lines).rstrip() + "\n"
+
+    if output_path:
+        with open(output_path, "w") as f:
+            f.write(output)
+        print(f"\nWritten to {output_path} ({len(objects)} objects)", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/subjugator/gnc/subjugator_vision/scripts/sim_detection_publisher.py
+++ b/src/subjugator/gnc/subjugator_vision/scripts/sim_detection_publisher.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""
+sim_detection_publisher.py
+
+Projects competition element 3D bounding boxes into camera image space using
+ground-truth Gazebo poses. Two modes (set via ROS parameters):
+
+  publish_detections=True  — publishes DetectionArray at 30 Hz so missions
+                              can run without YOLO or camera rendering
+  collect_data=True        — saves each incoming camera frame as a PNG with a
+                              YOLO-format .txt annotation file alongside it
+"""
+
+import os
+import threading
+
+import cv2
+import numpy as np
+import rclpy
+import yaml
+from ament_index_python.packages import get_package_share_directory
+from cv_bridge import CvBridge
+from gz.msgs10.pose_v_pb2 import Pose_V
+from gz.transport13 import Node as GzNode
+from rclpy.node import Node
+from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import CameraInfo, Image
+from yolo_msgs.msg import Detection, DetectionArray
+
+SENSOR_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+)
+
+
+class SimDetectionPublisher(Node):
+    def __init__(self):
+        super().__init__("sim_detection_publisher")
+
+        self.declare_parameter("config_file", "")
+        self.declare_parameter("publish_detections", True)
+        self.declare_parameter("collect_data", False)
+        self.declare_parameter("camera_topic", "/front_cam")
+        self.declare_parameter("output_dir", os.path.expanduser("~/sim_training_data"))
+
+        config_path = self.get_parameter("config_file").value
+        self.publish_detections = self.get_parameter("publish_detections").value
+        self.collect_data = self.get_parameter("collect_data").value
+        camera_topic = self.get_parameter("camera_topic").value
+        self.output_dir = os.path.expanduser(self.get_parameter("output_dir").value)
+
+        if not config_path:
+            config_path = os.path.join(
+                get_package_share_directory("subjugator_vision"),
+                "config",
+                "sim_objects.yaml",
+            )
+
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+
+        self.objects = config["objects"]
+        self.camera_link = config["camera_link"]
+        self._model_name = config.get("model_name", "sub9")
+        gz_pose_topic = config["gz_pose_topic"]
+
+        # Camera intrinsics — populated from /camera_info on first message
+        self.fx = self.fy = self.cx = self.cy = None
+        self.img_width = self.img_height = None
+
+        # Rotation from camera link frame to optical (image) frame.
+        # Camera link: X=forward, Y=left, Z=up  (robot convention, rpy=0 on sub)
+        # Optical frame: X=right, Y=down, Z=forward
+        self._R_opt = np.array([[0, -1, 0], [0, 0, -1], [1, 0, 0]], dtype=float)
+
+        # World-to-camera transform updated by the Gazebo pose callback
+        self._pose_lock = threading.Lock()
+        self._T_world_to_cam: np.ndarray | None = None
+
+        self.create_subscription(
+            CameraInfo,
+            f"{camera_topic}/camera_info",
+            self._camera_info_cb,
+            SENSOR_QOS,
+        )
+
+        if self.collect_data:
+            os.makedirs(self.output_dir, exist_ok=True)
+            self._bridge = CvBridge()
+            self.create_subscription(
+                Image,
+                f"{camera_topic}/image_raw",
+                self._image_cb,
+                SENSOR_QOS,
+            )
+            self.get_logger().info(f"collect_data mode: saving to {self.output_dir}")
+
+        if self.publish_detections:
+            self._det_pub = self.create_publisher(
+                DetectionArray,
+                "/yolo/detections",
+                10,
+            )
+            self.create_timer(1.0 / 30.0, self._publish_timer_cb)
+            self.get_logger().info(
+                "publish_detections mode: publishing on /yolo/detections",
+            )
+
+        # Gazebo subscriber runs callbacks on gz's own thread
+        self._gz_node = GzNode()
+        self._gz_node.subscribe(Pose_V, gz_pose_topic, self._gz_pose_cb)
+
+        self.get_logger().info(
+            f"Watching {len(self.objects)} objects, camera link: {self.camera_link}",
+        )
+
+    # ------------------------------------------------------------------
+    # Callbacks
+    # ------------------------------------------------------------------
+
+    def _camera_info_cb(self, msg: CameraInfo):
+        first = self.fx is None
+        self.fx = msg.k[0]
+        self.fy = msg.k[4]
+        self.cx = msg.k[2]
+        self.cy = msg.k[5]
+        self.img_width = msg.width
+        self.img_height = msg.height
+        if first:
+            self.get_logger().info(
+                f"Camera intrinsics: fx={self.fx:.1f} cx={self.cx} {self.img_width}x{self.img_height}",
+            )
+
+    def _gz_pose_cb(self, msg: Pose_V):
+        # dynamic_pose/info publishes the sub model in world frame, but nested
+        # link poses (like front_cam_link) are relative to that model.
+        # We must compose: T_cam_world = T_model_world @ T_cam_in_model.
+        model_pose = None
+        cam_pose = None
+        for pose in msg.pose:
+            if pose.name == self._model_name:
+                model_pose = pose
+            elif pose.name == self.camera_link:
+                cam_pose = pose
+            if model_pose is not None and cam_pose is not None:
+                break
+
+        if model_pose is None or cam_pose is None:
+            return
+
+        p, q = model_pose.position, model_pose.orientation
+        T_model_in_world = self._make_transform(p.x, p.y, p.z, q.x, q.y, q.z, q.w)
+
+        p, q = cam_pose.position, cam_pose.orientation
+        T_cam_in_model = self._make_transform(p.x, p.y, p.z, q.x, q.y, q.z, q.w)
+
+        T_cam_in_world = T_model_in_world @ T_cam_in_model
+        T_world_to_link = self._invert(T_cam_in_world)
+
+        T = np.eye(4)
+        T[:3, :3] = self._R_opt @ T_world_to_link[:3, :3]
+        T[:3, 3] = self._R_opt @ T_world_to_link[:3, 3]
+        with self._pose_lock:
+            self._T_world_to_cam = T
+
+    def _publish_timer_cb(self):
+        with self._pose_lock:
+            T = self._T_world_to_cam
+        if T is None or self.fx is None:
+            return
+
+        msg = DetectionArray()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self.camera_link
+
+        for obj in self.objects:
+            bbox = self._project(obj["position"], obj["half_extents"], T)
+            if bbox is not None:
+                msg.detections.append(self._build_detection(obj, bbox))
+
+        self._det_pub.publish(msg)
+
+    def _image_cb(self, msg: Image):
+        with self._pose_lock:
+            T = self._T_world_to_cam
+        if T is None or self.fx is None:
+            self.get_logger().warn(
+                f"image received but not ready: T={'set' if T is not None else 'None'}, fx={self.fx}",
+                throttle_duration_sec=2.0,
+            )
+            return
+
+        stamp = f"{msg.header.stamp.sec}_{msg.header.stamp.nanosec}"
+        lines = []
+
+        for obj in self.objects:
+            bbox = self._project(obj["position"], obj["half_extents"], T)
+            if bbox is None:
+                continue
+            cx, cy, w, h = bbox
+            lines.append(
+                f"{obj['class_id']} "
+                f"{cx / self.img_width:.6f} "
+                f"{cy / self.img_height:.6f} "
+                f"{w / self.img_width:.6f} "
+                f"{h / self.img_height:.6f}",
+            )
+
+        if not lines:
+            return
+
+        img = self._bridge.imgmsg_to_cv2(msg, "bgr8")
+        cv2.imwrite(os.path.join(self.output_dir, f"{stamp}.png"), img)
+        with open(os.path.join(self.output_dir, f"{stamp}.txt"), "w") as f:
+            f.write("\n".join(lines))
+
+        self.get_logger().info(f"Saved {stamp}.png  ({len(lines)} annotations)")
+
+    # ------------------------------------------------------------------
+    # Geometry helpers
+    # ------------------------------------------------------------------
+
+    def _make_transform(self, x, y, z, qx, qy, qz, qw) -> np.ndarray:
+        T = np.eye(4)
+        T[:3, 3] = [x, y, z]
+        T[:3, :3] = np.array(
+            [
+                [
+                    1 - 2 * (qy**2 + qz**2),
+                    2 * (qx * qy - qz * qw),
+                    2 * (qx * qz + qy * qw),
+                ],
+                [
+                    2 * (qx * qy + qz * qw),
+                    1 - 2 * (qx**2 + qz**2),
+                    2 * (qy * qz - qx * qw),
+                ],
+                [
+                    2 * (qx * qz - qy * qw),
+                    2 * (qy * qz + qx * qw),
+                    1 - 2 * (qx**2 + qy**2),
+                ],
+            ],
+        )
+        return T
+
+    def _invert(self, T: np.ndarray) -> np.ndarray:
+        R, t = T[:3, :3], T[:3, 3]
+        Ti = np.eye(4)
+        Ti[:3, :3] = R.T
+        Ti[:3, 3] = -R.T @ t
+        return Ti
+
+    def _project(self, position, half_extents, T_world_to_cam):
+        """Return (cx, cy, w, h) in pixels, or None if not visible."""
+        ox, oy, oz = position
+        dx, dy, dz = half_extents
+
+        corners = np.array(
+            [
+                [ox + sx * dx, oy + sy * dy, oz + sz * dz, 1.0]
+                for sx in (-1, 1)
+                for sy in (-1, 1)
+                for sz in (-1, 1)
+            ],
+        )
+
+        p_cam = (T_world_to_cam @ corners.T).T
+        visible = p_cam[:, 2] > 0.01
+        if not np.any(visible):
+            return None
+        p_cam = p_cam[visible]
+
+        u = self.fx * p_cam[:, 0] / p_cam[:, 2] + self.cx
+        v = self.fy * p_cam[:, 1] / p_cam[:, 2] + self.cy
+
+        x0 = float(np.clip(u.min(), 0, self.img_width))
+        x1 = float(np.clip(u.max(), 0, self.img_width))
+        y0 = float(np.clip(v.min(), 0, self.img_height))
+        y1 = float(np.clip(v.max(), 0, self.img_height))
+
+        if x1 <= x0 or y1 <= y0:
+            return None
+
+        return (x0 + x1) / 2, (y0 + y1) / 2, x1 - x0, y1 - y0
+
+    def _build_detection(self, obj, bbox) -> Detection:
+        cx, cy, w, h = bbox
+        det = Detection()
+        det.class_id = obj["class_id"]
+        det.class_name = obj["class_name"]
+        det.score = 1.0
+        det.bbox.center.position.x = cx
+        det.bbox.center.position.y = cy
+        det.bbox.size.x = w
+        det.bbox.size.y = h
+        return det
+
+
+def main():
+
+    rclpy.init()
+    node = SimDetectionPublisher()
+    try:
+        while rclpy.ok():
+            # spin_once with a short timeout releases the Python GIL while
+            # waiting, giving gz transport callbacks a window to execute.
+            rclpy.spin_once(node, timeout_sec=0.05)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/subjugator/gnc/subjugator_vision/scripts/sim_detection_publisher.py
+++ b/src/subjugator/gnc/subjugator_vision/scripts/sim_detection_publisher.py
@@ -43,12 +43,15 @@ class SimDetectionPublisher(Node):
         self.declare_parameter("collect_data", False)
         self.declare_parameter("camera_topic", "/front_cam")
         self.declare_parameter("output_dir", os.path.expanduser("~/sim_training_data"))
+        self.declare_parameter("save_every_n_frames", 10)
 
         config_path = self.get_parameter("config_file").value
         self.publish_detections = self.get_parameter("publish_detections").value
         self.collect_data = self.get_parameter("collect_data").value
         camera_topic = self.get_parameter("camera_topic").value
         self.output_dir = os.path.expanduser(self.get_parameter("output_dir").value)
+        self._save_every_n = self.get_parameter("save_every_n_frames").value
+        self._frame_count = 0
 
         if not config_path:
             config_path = os.path.join(
@@ -182,6 +185,10 @@ class SimDetectionPublisher(Node):
         self._det_pub.publish(msg)
 
     def _image_cb(self, msg: Image):
+        self._frame_count += 1
+        if self._frame_count % self._save_every_n != 0:
+            return
+
         with self._pose_lock:
             T = self._T_world_to_cam
         if T is None or self.fx is None:

--- a/src/subjugator/subjugator_bringup/config/subjugator_bridge.yaml
+++ b/src/subjugator/subjugator_bringup/config/subjugator_bridge.yaml
@@ -70,8 +70,18 @@
   ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"
   direction: GZ_TO_ROS
+- ros_topic_name: "/front_cam/camera_info"
+  gz_topic_name: "/front_cam/camera_info"
+  ros_type_name: "sensor_msgs/msg/CameraInfo"
+  gz_type_name: "gz.msgs.CameraInfo"
+  direction: GZ_TO_ROS
 - ros_topic_name: "/down_cam/image_raw"
   gz_topic_name: "/down_cam/image"
   ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"
+  direction: GZ_TO_ROS
+- ros_topic_name: "/down_cam/camera_info"
+  gz_topic_name: "/down_cam/camera_info"
+  ros_type_name: "sensor_msgs/msg/CameraInfo"
+  gz_type_name: "gz.msgs.CameraInfo"
   direction: GZ_TO_ROS


### PR DESCRIPTION
Closes #491

## What this does
Adds `sim_detection_publisher.py` — a ROS2 node that projects the 3D positions of competition elements into 2D bounding boxes on the front camera image, enabling two things:

1. **Training data collection** (`collect_data:=true`): as the sub moves through sim, automatically saves each camera frame as a PNG alongside a YOLO `.txt` label file to `~/sim_training_data/`
2. **Sim missions without YOLO** (`publish_detections:=true`): publishes ground-truth `DetectionArray` on `/yolo/detections` at 30Hz so missions can run in sim without a trained model

## How to run

**Step 1 — launch the sim as normal:**
```bash
ros2 launch subjugator_bringup gazebo.launch.py world:=robosub_2025.world
```

**Step 2 — in a new terminal, run the node:**
```bash
source install/setup.bash && export RMW_IMPLEMENTATION=rmw_fastrtps_cpp

ros2 run subjugator_vision sim_detection_publisher.py --ros-args \
  -p collect_data:=true \
  -p publish_detections:=false
```

Drive the sub around in sim and annotated images will save automatically to `~/sim_training_data/`.

## World configs

Each world file has a matching yaml config with the correct object positions. Make sure the world you launch matches the config you pass:

| World | Config |
|---|---|
| `robosub_2025.world` | `sim_objects.yaml` (default, no need to pass) |
| `task1_2026.world` | `sim_objects_task1_2026.yaml` |
| `task4_2026_v1.world` | `sim_objects_task4_2026_v1.yaml` |
| `task4_2026_v2.world` | `sim_objects_task4_2026_v2.yaml` |

To use a non-default config:
```bash
ros2 run subjugator_vision sim_detection_publisher.py --ros-args \
  -p collect_data:=true \
  -p config_file:=/path/to/mil2/src/subjugator/gnc/subjugator_vision/config/sim_objects_task4_2026_v1.yaml
```

## Files changed
- `scripts/sim_detection_publisher.py` — main node
- `config/sim_objects.yaml` — object positions for `robosub_2025.world`
- `config/sim_objects_task1_2026.yaml` — start gate for `task1_2026.world`
- `config/sim_objects_task4_2026_v1.yaml` — torpedo board for `task4_2026_v1.world`
- `config/sim_objects_task4_2026_v2.yaml` — torpedo board for `task4_2026_v2.world`
- `CMakeLists.txt` / `package.xml` — install the new script and configs
- `subjugator_bridge.yaml` — added camera_info bridge entries for both cameras
