### PR TITLE
update milpedia docker

### DIFF
--- a/infra/services/milpedia/Dockerfile
+++ b/infra/services/milpedia/Dockerfile
@@ -1,4 +1,4 @@
-FROM mediawiki:1.43.1
+FROM mediawiki:1.43.9
 
 # Commented out lines are already installed
 # RUN git clone --depth 1 https://github.com/wikimedia/mediawiki-extensions-Cite /var/www/html/extensions/Cite -b REL1_43
@@ -29,7 +29,7 @@ RUN git clone --depth 1 https://github.com/wikimedia/mediawiki-extensions-Citoid
     git clone --depth 1 https://github.com/wikimedia/mediawiki-extensions-TemplateStyles /var/www/html/extensions/TemplateStyles -b REL1_43
 
 # Install vim (for easier debugging) and wget
-RUN apt-get update && apt-get install -y vim=2:9.0.1378-2+deb12u2 wget=1.21.3-1+deb12u1 --no-install-recommends && \
+RUN apt-get update && apt-get install -y vim wget --no-install-recommends && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install composer


### PR DESCRIPTION
Updating fixes one of the issues (zip not found). The other (https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq) should be resolved eventually when the vulnerable dependency gets updated/backported to 1_43 https://phabricator.wikimedia.org/T434187